### PR TITLE
Miscellaneous bug fixes from internal git repository, along with clarifications to the documentation in response to external feedback.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,11 @@ Supported options are `--port` and `--dburi` which respectively change the local
 
 The web application can be run on top of multiple knowledge repo backends. To do this, include each repo with a name and path, prefixed by --repo. For example:
 
-`knowledge_repo --repo {git}/path/to/github/repo --repo {webposts}sqlite:////tmp/dbrepo.db:mypostreftable runserver`
+`knowledge_repo --repo {git}/path/to/git/repo --repo {webposts}sqlite:////tmp/dbrepo.db:mypostreftable runserver`
 
 If including a dbrepo, add the name of the dbrepo to the `WEB_EDITOR_PREFIXES` in the server config, and add it as config when running the app:
 
-`knowledge_repo --repo {git}/path/to/github/repo --repo {webposts}sqlite:////tmp/dbrepo.db:mypostreftable runserver --config resources/server_config.py`
+`knowledge_repo --repo {git}/path/to/git/repo --repo {webposts}sqlite:////tmp/dbrepo.db:mypostreftable runserver --config resources/server_config.py`
 
 Note that this is required for the webeditor, the "Write a Post!" section of the application.
 
@@ -94,7 +94,7 @@ Deploying is as simple as:
 `knowledge_repo --repo <repo_path> deploy`
 
 or if using multiple repos:
-`knowledge_repo --repo {git}/path/to/github/repo --repo {webposts}sqlite:////tmp/dbrepo.db:mypostreftable deploy --config resources/server_config.py`
+`knowledge_repo --repo {git}/path/to/git/repo --repo {webposts}sqlite:////tmp/dbrepo.db:mypostreftable deploy --config resources/server_config.py`
 
 Supported options are `--port`, `--dburi`,`--workers`, `--timeout` and `--config`. The `--config` option allows you to specify a python config file from which to load the extended configuration. A template config file is provided in `resources/server_config.py`. The `--port` and `--dburi` options are as before, with the `--workers` and `--timeout` options specifying the number of threads to use when serving through gunicorn, and the timeout after which the threads are presumed to have died, and will be restarted.
 

--- a/knowledge_repo/config.py
+++ b/knowledge_repo/config.py
@@ -28,40 +28,44 @@ class KnowledgeRepositoryConfig(dict):
     def __dir__(self):
         return list(set(list(self.DEFAULT_CONFIGURATION.keys()) + list(self.keys())))
 
-    def update(self, values):
-        if isinstance(values, dict):
-            if 'DEFAULT_CONFIGURATION' in values:
-                values = values.copy()
-                values.pop('DEFAULT_CONFIGURATION')
-            super(KnowledgeRepositoryConfig, self).update(values)
-        elif isinstance(values, types.ModuleType):
-            self.__update_from_module(values)
-        elif type(values) == str:
-            if os.path.exists(values):
-                self.__update_from_file(values)
+    def update(self, *values, **kwargs):
+        for value in values:
+            if isinstance(value, dict):
+                if 'DEFAULT_CONFIGURATION' in value:
+                    value = value.copy()
+                    value.pop('DEFAULT_CONFIGURATION')
+                dict.update(self, value)
+            elif isinstance(value, types.ModuleType):
+                self.__update_from_module(value)
+            elif type(value) == str:
+                if os.path.exists(value):
+                    self.__update_from_file(value)
+                else:
+                    logger.warning(
+                        "Configuration file {} does not exist.".format(value))
+            elif isinstance(value, types.NoneType):
+                pass
             else:
-                logger.warning(
-                    "Configuration file {} does not exist.".format(values))
-        elif isinstance(values, types.NoneType):
-            pass
-        else:
-            raise ValueError("Cannot interpret {}".format(values))
+                raise ValueError("Cannot interpret {}".format(value))
+        dict.update(self, kwargs)
 
-    def update_defaults(self, values):
-        if type(values) == dict:
-            self.DEFAULT_CONFIGURATION.update(values)
-        elif isinstance(values, types.ModuleType):
-            self.__defaults_from_module(values)
-        elif type(values) == str:
-            if os.path.exists(values):
-                self.__defaults_from_file(values)
+    def update_defaults(self, *values, **kwargs):
+        for value in values:
+            if type(value) == dict:
+                self.DEFAULT_CONFIGURATION.update(value)
+            elif isinstance(value, types.ModuleType):
+                self.__defaults_from_module(value)
+            elif type(value) == str:
+                if os.path.exists(value):
+                    self.__defaults_from_file(value)
+                else:
+                    logger.warning(
+                        "Configuration file {} does not exist.".format(value))
+            elif isinstance(value, types.NoneType):
+                pass
             else:
-                logger.warning(
-                    "Configuration file {} does not exist.".format(values))
-        elif isinstance(values, types.NoneType):
-            pass
-        else:
-            raise ValueError("Cannot interpret {}".format(values))
+                raise ValueError("Cannot interpret {}".format(value))
+        self.DEFAULT_CONFIGURATION.update(kwargs)
 
     def __defaults_from_file(self, filename):
         self.__set_from_file(self.DEFAULT_CONFIGURATION, filename, force=True)

--- a/knowledge_repo/converters/rmd.py
+++ b/knowledge_repo/converters/rmd.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import logging
 import subprocess
 import tempfile
@@ -20,8 +19,7 @@ class RmdConverter(KnowledgePostConverter):
 
             runcmd = """R --vanilla --slave -e "library(knitr); setwd('{0}'); \
                         x = knit('{1}', '{2}', quiet=T)" """.format(os.path.abspath(os.path.dirname(filename)),
-                                                                    os.path.abspath(
-                                                                        filename),
+                                                                    os.path.abspath(filename),
                                                                     tmp_path)
             subprocess.check_output(runcmd, shell=True)
             Rmd_filename = tmp_path
@@ -29,3 +27,7 @@ class RmdConverter(KnowledgePostConverter):
         with open(Rmd_filename) as f:
             self.kp.write(f.read())
         self.kp.add_srcfile(filename)
+
+        # Clean up temporary file
+        if rebuild:
+            os.remove(tmp_path)

--- a/knowledge_repo/repository.py
+++ b/knowledge_repo/repository.py
@@ -79,6 +79,17 @@ class KnowledgeRepository(object):
         krs = {name: cls.for_uri(uri) for name, uri in uris.items()}
         return MetaKnowledgeRepository(krs)
 
+    @classmethod
+    def create_for_uri(cls, uri, **kwargs):
+        if isinstance(uri, dict):
+            return cls.for_uris(uri)
+        scheme = urlparse(uri).scheme
+        return cls._get_subclass_for(scheme).create(uri, **kwargs)
+
+    @classmethod
+    def create(cls, uri, **kwargs):
+        raise NotImplementedError
+
     def __init__(self, uri, debug=False, **kwargs):
         self.uri = uri
         self.config = KnowledgeRepositoryConfig()

--- a/knowledge_repo/templates/repo_data_readme.md
+++ b/knowledge_repo/templates/repo_data_readme.md
@@ -38,7 +38,7 @@ If you have already set up your system as described below, here is a snapshot of
 2. knowledge_repo add ~/Documents/my_post.ipynb [-p projects/test_project] [--update]
 3. knowledge_repo preview projects/test_project
 4. knowledge_repo submit projects/test_project
-5. Open a PR in GitHub
+5. [If applicable] Open a PR in GitHub or other git web UI
 6. After it has been reviewed, merge it in to master.
 
 For more details, read on.
@@ -161,11 +161,11 @@ If you've been cautious and didn't shortcut the previewing process, and your pos
 
 `knowledge_repo --repo <knowledge_repo_path> push <project_branch>`
 
-### 4. Open a pull request in Github
+### 4. [If applicable] Open a pull request in Github or other git web ui
 
-Visit this repo's github page and create a new pull request from the yellow bar that appears above the files currently in the repo. It should have the name of your post as the branch name.
+Visit this repo's git web ui and create a new pull request. In GitHub this is done from the yellow bar that appears above the files currently in the repo. The branch to be merged should have the same name as the path of your post.
 
-Be sure to **label your pull request** with the appropriate label:
+Be sure to **label your pull request** with the appropriate label. For example, your organization might use:
 
 * **WIP** - _"this is a work in progress, don't look yet"_
 * **Review** - _"this is ready to be reviewed"_ - Someone in your organization should take a look as soon as possible, hopefully within a day or so.

--- a/resources/extract_images_to_s3.py
+++ b/resources/extract_images_to_s3.py
@@ -22,30 +22,35 @@ class ExtractImagesToS3(ExtractImages):
     def copy_image(cls, kp, img_path, is_ref=False, repo_name='knowledge'):
         # Copy image data to new file
         if is_ref:
-            tmp_file, tmp_path = tempfile.mkstemp()
+            _, tmp_path = tempfile.mkstemp()
             with open(tmp_path, 'w') as f:
                 f.write(kp._read_ref(img_path))
         else:
             tmp_path = img_path
 
-        # Get image type
-        img_ext = os.path.splitext(img_path)[1]
+        try:
+            # Get image type
+            img_ext = os.path.splitext(img_path)[1]
 
-        # Make random filename for image
-        random_string = ''.join(random.choice(string.ascii_lowercase) for i in range(6))
-        fname_img = '{repo_name}_{time}_{random_string}{ext}'.format(
-            repo_name=repo_name,
-            time=int(round(time.time() * 100)),
-            random_string=random_string,
-            ext=img_ext).strip().replace(' ', '-')
+            # Make random filename for image
+            random_string = ''.join(random.choice(string.ascii_lowercase) for i in range(6))
+            fname_img = '{repo_name}_{time}_{random_string}{ext}'.format(
+                repo_name=repo_name,
+                time=int(round(time.time() * 100)),
+                random_string=random_string,
+                ext=img_ext).strip().replace(' ', '-')
 
-        # Copy image to accessible folder on S3
-        fname_s3 = os.path.join(S3_IMAGE_ROOT, repo_name, fname_img)
-        cmd = "awc-mfa aws s3 cp '{0}' {1}".format(tmp_path, fname_s3)
-        logger.info("Uploading images to S3: {cmd}".format(cmd=cmd))
-        retval = os.system(cmd)
-        if retval != 0:
-            raise Exception('Problem uploading images to s3')
+            # Copy image to accessible folder on S3
+            fname_s3 = os.path.join(S3_IMAGE_ROOT, repo_name, fname_img)
+            cmd = "awc-mfa aws s3 cp '{0}' {1}".format(tmp_path, fname_s3)
+            logger.info("Uploading images to S3: {cmd}".format(cmd=cmd))
+            retval = os.system(cmd)
+            if retval != 0:
+                raise Exception('Problem uploading images to s3')
+        finally:
+            # Clean up temporary file
+            if is_ref:
+                os.remove(tmp_path)
 
         # return uploaded path of file
         return os.path.join(HTTP_IMAGE_ROOT, repo_name, fname_img)

--- a/scripts/knowledge_repo
+++ b/scripts/knowledge_repo
@@ -2,6 +2,7 @@
 
 import sys
 import os
+import signal
 import re
 import threading
 import webbrowser
@@ -9,7 +10,9 @@ import shutil
 import argparse
 import subprocess
 from tabulate import tabulate
-from alembic import command
+
+# Register handler for SIGTERM, so we can run cleanup code if we are terminated
+signal.signal(signal.SIGTERM, lambda signum, frame: sys.exit(0))
 
 # If this script is being run out of a checked out repository, we need to make sure
 # the appropriate knowledge_repo is being used. To do this, we add the parent directory
@@ -77,11 +80,17 @@ if args.main_help:
 if args.repo is None:
     raise ValueError("No repository specified. Please set the --repo flag, or the KNOWLEDGE_REPO environment variable.")
 
-# Update repository so that git submodules are initialised
+# Update repository so that we can ensure git repository configuration is up to date
+# We wrap this in a try/except block because failing to update a repository can
+# happen for all sorts of reasons that should not inhibit other actions
+# For example: if the repository does not exist and the action will be 'init'
 if args.update:
-    kr = knowledge_repo.KnowledgeRepository.for_uri(args.repo)
-    if isinstance(kr, GitKnowledgeRepository):
-        kr.update(branch=args.knowledge_branch)
+    try:
+        kr = knowledge_repo.KnowledgeRepository.for_uri(args.repo)
+        if isinstance(kr, GitKnowledgeRepository):
+            kr.update(branch=args.knowledge_branch)
+    except:
+        pass
 
 # If not running in dev mode, and the specified repo exists, along with a knowledge_repo
 # script in the .resources/scripts folder, pass execution to this script in the
@@ -105,8 +114,11 @@ if (isinstance(args.repo, str) and not args.dev
 # Add the action parsers
 subparsers = parser.add_subparsers(help='sub-commands')
 
-init = subparsers.add_parser('init', help='Initialise a new knowledge repository.')
+init = subparsers.add_parser('init', help='Initialise a new git knowledge repository.')
 init.set_defaults(action='init')
+init.add_argument('--tooling-skip', action='store_true', help='Disable embedding of knowledge_repo tooling.')
+init.add_argument('--tooling-repo', help='The repository to use (if not the default).')
+init.add_argument('--tooling-branch', help='The branch to use when embedding the tools as a submodule.')
 
 create = subparsers.add_parser('create', help='Start a new knowledge post based on a template.')
 create.set_defaults(action='create')
@@ -142,6 +154,7 @@ preview.set_defaults(action='preview')
 preview.add_argument('path', help="The path of the knowledge post to preview.")
 preview.add_argument('--port', default=7000, type=int, help="Specify the port on which to run the web server")
 preview.add_argument('--dburi', help='The SQLAlchemy database uri.')
+preview.add_argument('--config', default=None)
 
 # Developer and server side actions
 runserver = subparsers.add_parser('runserver', help='Run the knowledge repo app.')
@@ -178,7 +191,16 @@ args = parser.parse_args()
 
 # If init, use this code to create a new repository.
 if args.action == 'init':
-    knowledge_repo.KnowledgeRepository.for_uri(args.repo, auto_create=True)
+    if args.tooling_skip:
+        embed_tooling = False
+    else:
+        embed_tooling = {}
+        if args.tooling_repo is not None:
+            embed_tooling['repository'] = args.tooling_repo
+        if args.tooling_branch is not None:
+            embed_tooling['branch'] = args.tooling_branch
+    kr = knowledge_repo.KnowledgeRepository.create_for_uri(args.repo, embed_tooling=embed_tooling)
+    print "Knowledge repository created for uri `{}`.".format(kr.uri)
     sys.exit(0)
 
 # All subsequent actions perform an action on the repository, and so we instantiate
@@ -227,7 +249,7 @@ if args.action in ['preview', 'runserver']:
 
     if args.action == 'preview':
         kp_path = repo._kp_path(args.path)
-        repo.set_active_draft(kp_path)
+        repo.set_active_draft(kp_path)  # TODO: Deprecate
         url = 'http://127.0.0.1:{}/render?markdown={}'.format(args.port, kp_path)
         threading.Timer(1.25, lambda: webbrowser.open(url)).start()
 
@@ -255,9 +277,13 @@ import knowledge_repo
 app = knowledge_repo.KnowledgeRepository.for_uri({}).get_app(db_uri={}, debug={}, config={})
         '''.format(kr_path, uris, db_uri, str(args.debug), '"' + os.path.abspath(args.config) + '"' if args.config is not None else "None"))
 
-    cmd = "cd {}; gunicorn -w {} --timeout {} -b 0.0.0.0:{} server:app".format(tmp_dir, args.workers, args.timeout, args.port)
-    # logger.info("Starting server with command:  " + " ".join(cmd))
-    subprocess.check_output(cmd, shell=True)
+    try:
+        # Run gunicorn server
+        cmd = "cd {}; gunicorn -w {} --timeout {} -b 0.0.0.0:{} server:app".format(tmp_dir, args.workers, args.timeout, args.port)
+        # logger.info("Starting server with command:  " + " ".join(cmd))
+        subprocess.check_output(cmd, shell=True)
+    finally:
+        shutil.rmtree(tmp_dir)
 
 elif args.action == 'db_upgrade':
     app = repo.get_app(db_uri=args.dburi, debug=args.debug, config=args.config)


### PR DESCRIPTION
In particular, this patch addresses the following:
- ENH: Clarify documentation pertaining to git repositories, which previously implied GitHub was necessary.
- ENH: Clean up any created temporary files and directories.
- ENH: Allows git repositories to specify which branch is published. By default this is `master`.
- BUG: The `preview` action in the `knowledge_repo` did not set a required `config` key.
- BUG: Fixes the `preview` action not detecting draft posts.
