### PR TITLE
This patch fixes unnecessary imports of `wand` and `PyPDF2`; and allows repositories to be initialised from pre-existing repositories.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If not, or for fun, you can create a new knowledge repository using:
 
 `knowledge_repo --repo <repo_path> init`
 
-Running this same script if a repo already exists at `<repo_path>` will have no effect.
+Running this same script if a repo already exists at `<repo_path>` will allow you to update it to be a knowledge data repository. This is useful if you are starting a repository on a remote service like GitHub, as this allows you to clone the remote repository as per normal; run this script; and then push the initialization back into the remote service using `git push`.
 
 You can drop the `--repo` option if you set the `$KNOWLEDGE_REPO` environment variable to the location of that repository.
 

--- a/knowledge_repo/app/utils/image.py
+++ b/knowledge_repo/app/utils/image.py
@@ -1,8 +1,6 @@
 import imghdr
 import io
 import os
-import PyPDF2
-from wand.image import Image
 
 ALLOWED_IMAGE_TYPES = ('png', 'jpeg', 'gif')
 
@@ -27,6 +25,11 @@ def pdf_page_to_png(src_pdf, pagenum=0, resolution=154):
     :param int pagenum: Page number to take.
     :param int resolution: Resolution for resulting png in DPI.
     """
+
+    # Import libraries within this function so as to avoid import-time dependence
+    import PyPDF2
+    from wand.image import Image  # TODO: When we start using this again, document which system-level libraries are required.
+
     dst_pdf = PyPDF2.PdfFileWriter()
     dst_pdf.addPage(src_pdf.getPage(pagenum))
 

--- a/scripts/knowledge_repo
+++ b/scripts/knowledge_repo
@@ -200,7 +200,8 @@ if args.action == 'init':
         if args.tooling_branch is not None:
             embed_tooling['branch'] = args.tooling_branch
     kr = knowledge_repo.KnowledgeRepository.create_for_uri(args.repo, embed_tooling=embed_tooling)
-    print "Knowledge repository created for uri `{}`.".format(kr.uri)
+    if kr is not None:
+        print "Knowledge repository created for uri `{}`.".format(kr.uri)
     sys.exit(0)
 
 # All subsequent actions perform an action on the repository, and so we instantiate


### PR DESCRIPTION
ENH: Don't import modules that are not needed during import phase that also require particular non-Python software to be installed (wand requires ImageMagick to be available at import time).
ENH: Allow git repository initialisation from an existing git repository.
