### PR TITLE
Use distinct views in the feed rather than total views

### DIFF
--- a/knowledge_repo/app/templates/index-feed.html
+++ b/knowledge_repo/app/templates/index-feed.html
@@ -15,7 +15,7 @@
           </a>
         </div>
         <div class='feed-post-counts'>
-          <i class="glyphicon glyphicon-eye-open"> </i> {{ stats['all_views'] }}&nbsp
+          <i class="glyphicon glyphicon-eye-open"> </i> {{ stats['distinct_views'] }}&nbsp
           <i class="glyphicon glyphicon-heart-empty"></i> {{ stats['total_likes']}}&nbsp
           <i class="glyphicon glyphicon-comment"></i> {{ stats['total_comments']}}
         </div>


### PR DESCRIPTION
Total Views is too easy to change by a single user. We should display distinct views on the feed page.

@matthewwardrop @earthmancash @NiharikaRay 
