### PR TITLE
Add UUIDs to posts, and track them (allows renaming of posts without losing votes/etc)

### DIFF
--- a/knowledge_repo/app/models.py
+++ b/knowledge_repo/app/models.py
@@ -431,6 +431,7 @@ class Post(db.Model):
         """
         headers = kp.headers
 
+        self.uuid = kp.uuid
         self.path = kp.path
         self.project = headers.get('project')
         self.repository = kp.repository_uri

--- a/knowledge_repo/post.py
+++ b/knowledge_repo/post.py
@@ -10,6 +10,7 @@ import datetime
 import yaml
 import mimetypes
 import base64
+import uuid
 
 from .utils.encoding import encode, decode
 
@@ -166,6 +167,19 @@ class KnowledgePost(object):
     @path.setter
     def path(self, path):
         self._path = path
+
+    @property
+    def uuid(self):
+        if not getattr(self, '_uuid', None):
+            if self.repository is not None:
+                self._uuid = self.repository._kp_uuid(self.path)  # Use repository UUID (even if None)
+            else:
+                self._uuid = str(uuid.uuid4())
+        return self._uuid
+
+    @uuid.setter
+    def uuid(self, uuid):
+        self._uuid = uuid
 
     # ------------ Reference cache methods ------------------------------------------
     def _read_ref(self, ref):

--- a/knowledge_repo/repositories/gitrepository.py
+++ b/knowledge_repo/repositories/gitrepository.py
@@ -372,6 +372,12 @@ class GitKnowledgeRepository(KnowledgeRepository):
 
     # ------------ Knowledge Post Data Retrieval Methods -------------------------
 
+    def _kp_uuid(self, path):
+        try:
+            return self._kp_read_ref(path, 'UUID')
+        except:
+            return None
+
     def _kp_path(self, path, rel=None):
         return KnowledgeRepository._kp_path(self, os.path.expanduser(path), rel=rel or self.path)
 
@@ -415,7 +421,7 @@ class GitKnowledgeRepository(KnowledgeRepository):
         # revisions because using git rev-parse is slow.
         try:
             return int(self._kp_read_ref(path, 'REVISION'))
-        except IOError:
+        except:
             return 0
 
     def _kp_get_revisions(self, path):  # slow
@@ -425,7 +431,7 @@ class GitKnowledgeRepository(KnowledgeRepository):
         # of a non-bare git repository.
         raise NotImplementedError
 
-    def _kp_write_ref(self, path, reference, data, revision=None):
+    def _kp_write_ref(self, path, reference, data, uuid=None, revision=None):
         ref_path = os.path.join(self.path, path, reference)
         ref_dir = os.path.dirname(ref_path)
         if not os.path.exists(ref_dir):
@@ -446,8 +452,10 @@ class GitKnowledgeRepository(KnowledgeRepository):
     def _kp_diff(self, path, head, base):
         raise NotImplementedError
 
-    def _kp_new_revision(self, path):
+    def _kp_new_revision(self, path, uuid=None):
         self._kp_write_ref(path, "REVISION", encode(self._kp_get_revision(path) + 1))
+        if uuid:
+            self._kp_write_ref(path, "UUID", encode(uuid))
 
     def _kp_read_ref(self, path, reference, revision=None):
         with open(os.path.join(self.path, path, reference), 'rb') as f:

--- a/knowledge_repo/repositories/meta.py
+++ b/knowledge_repo/repositories/meta.py
@@ -129,8 +129,8 @@ class MetaKnowledgeRepository(KnowledgeRepository):
     def _kp_diff(self, path, head, base):
         return self.__delegate_for_path(path, '_kp_diff', head=head, base=base)
 
-    def _kp_write_ref(self, path, reference, data, revision=None):
-        return self.__delegate_for_path(path, '_kp_write_ref', reference=reference, data=data, revision=revision)
+    def _kp_write_ref(self, path, reference, data, uuid=None, revision=None):
+        return self.__delegate_for_path(path, '_kp_write_ref', reference=reference, data=data, uuid=uuid, revision=revision)
 
-    def _kp_new_revision(self, path):
-        return self.__delegate_for_path(path, '_kp_new_revision')
+    def _kp_new_revision(self, path, uuid=None):
+        return self.__delegate_for_path(path, '_kp_new_revision', uuid=uuid)

--- a/knowledge_repo/repositories/stub.py
+++ b/knowledge_repo/repositories/stub.py
@@ -63,6 +63,9 @@ class StubKnowledgeRepository(KnowledgeRepository):
 
     # ----------- Knowledge Post Data Retrieval/Pushing Methods --------------------
 
+    def _kp_uuid(self, path):
+        raise NotImplementedError
+
     def _kp_exists(self, path, revision=None):
         raise NotImplementedError
 
@@ -87,8 +90,8 @@ class StubKnowledgeRepository(KnowledgeRepository):
     def _kp_diff(self, path, head, base):
         raise NotImplementedError
 
-    def _kp_write_ref(self, path, reference, data, revision=None):
+    def _kp_write_ref(self, path, reference, data, uuid=None, revision=None):
         raise NotImplementedError
 
-    def _kp_new_revision(self, path):
+    def _kp_new_revision(self, path, uuid=None):
         raise NotImplementedError


### PR DESCRIPTION
UUIDs are automatically generated when posts are saved, and inserted into the index database. Where present, they are used to keep track of moved posts, allowing vote counts and views to be maintained. It also handles cases where two or more posts have both been moved with overlapping paths.
