### PR TITLE
Add automatic checks for dependencies at runtime.

### DIFF
--- a/knowledge_repo/_version.py
+++ b/knowledge_repo/_version.py
@@ -1,6 +1,6 @@
 import subprocess
 
-__all__ = ['__author__', '__author_email__', '__version__', '__git_uri__']
+__all__ = ['__author__', '__author_email__', '__version__', '__git_uri__', '__dependencies__']
 
 __author__ = "Nikki Ray (maintainer), Robert Chang, Dan Frank,  Chetan Sharma,  Matthew Wardrop"
 __author_email__ = "nikki.ray@airbnb.com, robert.chang@airbnb.com, dan.frank@airbnb.com, chetan.sharma@airbnb.com, matthew.wardrop@airbnb.com"
@@ -10,3 +10,30 @@ try:
 except:
     pass
 __git_uri__ = "git@github.com:airbnb/knowledge-repo.git"
+
+__dependencies__ = [
+    # Knowledge Repository Dependencies
+    'markdown',  # Markdown conversion utilities
+    'nbconvert',  # Jupyter notebook conversion utilities
+    'nbformat',  # Jupyter notebook reference format
+    'gitpython',  # Git abstraction
+    'pyyaml',  # Yaml parser and utilities
+    'tabulate',  # Rendering user information prettily
+    'enum34',  # Post status enum object
+    'future',  # Python 2/3 support
+    # Flask App Dependencies
+    'flask',  # Main flask framework
+    'flask_mail',  # Mail client and utilities
+    'Flask-Migrate',  # Database migration utilities
+    'sqlalchemy',  # Database abstractions
+    'jinja2>=2.7',  # Templating engine
+    'werkzeug',  # Development webserver
+    'gunicorn',  # Deployed webserver
+    'inflection',  # String transformation library
+    'PyPDF2',  # image for parsing PDFs to images
+    'wand',  # imagemagick integration for image uploading
+    'Pillow',  # image processing for sending images
+    # Testing Dependencies
+    'nose',  # Testing framework
+    'beautifulsoup4'  # HTML/XML parser
+]

--- a/scripts/knowledge_repo
+++ b/scripts/knowledge_repo
@@ -13,6 +13,7 @@ import shutil
 import argparse
 import subprocess
 from tabulate import tabulate
+import pkg_resources
 
 # Register handler for SIGTERM, so we can run cleanup code if we are terminated
 signal.signal(signal.SIGTERM, lambda signum, frame: sys.exit(0))
@@ -25,6 +26,22 @@ if os.path.exists(os.path.join(os.path.dirname(script_dir), 'knowledge_repo', '_
     sys.path.insert(0, os.path.join(script_dir, '..'))
 import knowledge_repo  # nopep8
 from knowledge_repo.repositories.gitrepository import GitKnowledgeRepository  # nopep8
+
+# Check if all dependencies are installed
+missing_deps = []
+for dep in knowledge_repo.__dependencies__:
+    try:
+        pkg_resources.get_distribution(dep)
+    except:
+        missing_deps.append(dep)
+if missing_deps:
+    print("Whoops! The knowledge_repo tool has been updated and you are missing "
+          "some of the required dependencies. You can fix this by running:\n\n"
+          "\tpip install --upgrade " + " ".join(missing_deps) + "\n\n"
+          "Note: Depending on your system's installation of Python, you may "
+          "need to use `pip2` or `pip3` instead of `pip`."
+          )
+    sys.exit(1)
 
 # If there's a contrib folder, add this as well and import it
 contrib_dir = os.path.join(os.path.dirname(__file__), os.pardir, 'contrib')

--- a/setup.py
+++ b/setup.py
@@ -64,32 +64,7 @@ setup(
     zip_safe=False,
     include_package_data=True,  # See included paths in MANIFEST.in
     scripts=['scripts/knowledge_repo'],
-    install_requires=[
-        # Knowledge Repository Dependencies
-        'markdown',  # Markdown conversion utilities
-        'nbconvert',  # Jupyter notebook conversion utilities
-        'nbformat',  # Jupyter notebook reference format
-        'gitpython',  # Git abstraction
-        'pyyaml',  # Yaml parser and utilities
-        'tabulate',  # Rendering user information prettily
-        'enum34',  # Post status enum object
-        'future',  # Python 2/3 support
-        # Flask App Dependencies
-        'flask',  # Main flask framework
-        'flask_mail',  # Mail client and utilities
-        'Flask-Migrate',  # Database migration utilities
-        'sqlalchemy',  # Database abstractions
-        'jinja2>=2.7',  # Templating engine
-        'werkzeug',  # Development webserver
-        'gunicorn',  # Deployed webserver
-        'inflection',  # String transformation library
-        'PyPDF2',  # image for parsing PDFs to images
-        'wand',  # imagemagick integration for image uploading
-        'Pillow',  # image processing for sending images
-        # Testing Dependencies
-        'nose',  # Testing framework
-        'beautifulsoup4'  # HTML/XML parser
-    ],
+    install_requires=version_info['__dependencies__'],
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Console',


### PR DESCRIPTION
Currently when the embedded tooling is updated, there is no intuitive or automatic way for a user to figure out which dependencies they need to install. This patch presents the user with the command required to garner all of the required dependencies.
