### PR TITLE
Miscellaneous fixes including: fixing local images, and using debug flag and path_parse appropriately.

### DIFF
--- a/knowledge_repo/converters/html.py
+++ b/knowledge_repo/converters/html.py
@@ -93,8 +93,7 @@ class HTMLConverter(KnowledgePostConverter):
         html = ''
         if not skip_headers:
             html += self.render_headers()
-        html += markdown.Markdown(extensions=MARKDOWN_EXTENSTIONS).convert(
-            self.kp.read())
+        html += markdown.Markdown(extensions=MARKDOWN_EXTENSTIONS).convert(self.kp.read())
 
         return self.apply_url_remapping(html, urlmappers)
 
@@ -144,5 +143,5 @@ class HTMLConverter(KnowledgePostConverter):
                 image_data = base64.b64encode(self.kp_images[url])
                 image_mimetype = mimetypes.guess_type(url)[0]
                 if image_mimetype is not None:
-                    return 'data:{};base64, '.format(image_mimetype) + image_data
+                    return 'data:{};base64, '.format(image_mimetype) + image_data.decode('utf-8')
         return None

--- a/knowledge_repo/postprocessors/extract_images.py
+++ b/knowledge_repo/postprocessors/extract_images.py
@@ -39,17 +39,17 @@ class ExtractImages(KnowledgePostProcessor):
             if cls.skip_image(kp, image):
                 continue
             orig_path = os.path.join(kp.orig_context, image['src'])
+
+            new_path = None
             if kp._has_ref(image['src']):
                 new_path = cls.copy_image(kp, image['src'], is_ref=True)
-                md = cls.replace_image_locations(md, image['offset'], image[
-                                                 'tag'], image['src'], new_path)
             elif os.path.exists(orig_path):
                 new_path = cls.copy_image(kp, orig_path)
-                md = cls.replace_image_locations(md, image['offset'], image[
-                                                 'tag'], image['src'], new_path)
             else:
-                logger.warning(
-                    "Could not find an image at: {}".format(image['src']))
+                logger.warning("Could not find an image at: {}".format(image['src']))
+            if not new_path:
+                continue
+            md = cls.replace_image_locations(md, image['offset'], image['tag'], image['src'], new_path)
         kp.write(md)
 
     @classmethod
@@ -62,7 +62,8 @@ class ExtractImages(KnowledgePostProcessor):
 
     @classmethod
     def copy_image(cls, kp, path, is_ref=False):
-        assert not is_ref, "This method only supports copy from a filesystem into the knowledge post."
+        if is_ref:
+            return
         with open(path) as f:
             kp.write_image(os.path.basename(path), f.read())
         return os.path.join('images', os.path.basename(path))

--- a/knowledge_repo/repositories/dbrepository.py
+++ b/knowledge_repo/repositories/dbrepository.py
@@ -1,6 +1,7 @@
 from builtins import object
 
 import logging
+import posixpath
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, scoped_session, mapper
@@ -204,6 +205,8 @@ class DbKnowledgeRepository(KnowledgeRepository):
         return data
 
     def _kp_dir(self, path, parent=None, revision=None):
+        if parent:
+            path = posixpath.join(path, parent)
         revision = revision or self._kp_get_revision(path, enforce_exists=True)
         refs = (self.session.query(self.PostRef.ref)
                             .filter(self.PostRef.path == path)

--- a/knowledge_repo/repositories/gitrepository.py
+++ b/knowledge_repo/repositories/gitrepository.py
@@ -131,7 +131,7 @@ class GitKnowledgeRepository(KnowledgeRepository):
         current_branch.checkout()
 
     def set_active_draft(self, path):  # TODO: deprecate
-        branch = self.git_branch_for_post(path)
+        branch = self.git_branch_for_post(self._kp_path(path))
         self.config.published_branch = branch.name
         branch.checkout()
 
@@ -440,6 +440,8 @@ class GitKnowledgeRepository(KnowledgeRepository):
             return f.write(data)
 
     def _kp_dir(self, path, parent=None, revision=None):  # TODO: Account for revision
+        if parent:
+            path = os.path.join(path, parent)
         for dirpath, dirnames, filenames in os.walk(os.path.join(self.path, path)):
             for filename in filenames:
                 if dirpath == "" and filename == "REVISION":

--- a/knowledge_repo/repository.py
+++ b/knowledge_repo/repository.py
@@ -186,6 +186,7 @@ class KnowledgeRepository(with_metaclass(SubclassRegisteringABCMeta, object)):
         if not path:
             raise ValueError("Post path not provided for Knowledge Post, and one is not specified within the knowledge post. Either add the path to post headers using `path: <path>` or specify the project path on the command line adding `-p <path>` to the current command.")
         path = self._kp_path(path)
+        path = self.config.path_parse(path)
 
         current_datetime = datetime.datetime.now()
         authors = kp.headers['authors']
@@ -267,7 +268,6 @@ class KnowledgeRepository(with_metaclass(SubclassRegisteringABCMeta, object)):
         path = os.path.relpath(os.path.abspath(os.path.join(rel, path)), rel)
         if os.name == 'nt':
             path = path.replace(os.path.sep, os.path.altsep)
-        path = self.config.path_parse(path)
         assert all([not segment.endswith('.kp') for segment in path.split(
             '/')[:-1]]), "The post path may not contain a directory named '*.kp'."
         if path == '.' or path.startswith('..'):

--- a/scripts/knowledge_repo
+++ b/scripts/knowledge_repo
@@ -280,7 +280,7 @@ if args.action in ['preview', 'runserver']:
         url = 'http://127.0.0.1:{}/render?markdown={}'.format(args.port, kp_path)
         threading.Timer(1.25, lambda: webbrowser.open(url)).start()
 
-    use_reloader = args.dev and args.action == 'runserver'
+    use_reloader = args.debug and args.action == 'runserver'
     threaded = True
     # Check if in-memory databases are being used, and if so, avoid using threading
     uris = []
@@ -300,7 +300,7 @@ if args.action in ['preview', 'runserver']:
             threaded = False
             break
 
-    app.run(debug=args.dev,
+    app.run(debug=args.debug,
             host='0.0.0.0',
             port=args.port,
             use_reloader=use_reloader,


### PR DESCRIPTION
This patch fixes the following issues:
- Use debug flag properly in the knowledge_repo script
- Use path_parse only when adding or modifying a path (according to spec)
- Fixing rendering local images as base64 urls when not stored in kp cache.
- Fix using absolute paths to specific paths in GitKnowledgeRepository.set_active_draft (still a deprecated work flow that will be removed when new GitKnowledgeRepository work lands).
