### PR TITLE
If there is no remote branch, add posts directly into the master branch

### DIFF
--- a/knowledge_repo/repositories/gitrepository.py
+++ b/knowledge_repo/repositories/gitrepository.py
@@ -308,7 +308,11 @@ class GitKnowledgeRepository(KnowledgeRepository):
     # ------------- Post submission / addition user flow ----------------------
     def _add_prepare(self, kp, path, update=False, branch=None, squash=False, message=None):
         target = os.path.abspath(os.path.join(self.path, path))
-        branch = branch or path
+        if self.__remote_uri:
+            branch = branch or path
+        else:
+            logger.warning("This repository does not have a remote, and so post review is being skipped. Adding post directly into published branch...")
+            branch = self.config.published_branch
 
         # Create or checkout the appropriate branch for this project
         logger.info("Checking out (and/or creating) a new branch `{}`...".format(branch))


### PR DESCRIPTION
This is great for testing and for personal knowledge management, without breaking any of the standard workflow.
