### PR TITLE
Use --help rather than --main-help for top-level help.

### DIFF
--- a/scripts/knowledge_repo
+++ b/scripts/knowledge_repo
@@ -89,11 +89,11 @@ parser.add_argument('--knowledge-branch', dest='knowledge_branch', help='The bra
 parser.add_argument('--dev', action='store_true', help='Whether to skip passing control to version of code checked out in knowledge repository.')
 parser.add_argument('--debug', action='store_true', help='Whether to enable debug mode.')
 parser.add_argument('--noupdate', dest='update', action='store_false', help='Whether script should update the repository before performing actions.')
-parser.add_argument('--main-help', action='store_true', help='Show help and exit.')
+parser.add_argument('-h', '--help', action='store_true', help='Show help and exit.')
 
-args = parser.parse_known_args()[0]
+args, remaining_args = parser.parse_known_args()
 
-if args.main_help:
+if args.help and not remaining_args:
     parser.print_help()
     sys.exit(0)
 


### PR DESCRIPTION
This patch addresses some long-standing confusing behaviour of the knowledge_repo script when it comes to showing help. Should now work largely as expected.
