### PR TITLE
Add support for soft dependencies, and use them for pdf upload and ipynb support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - conda install -c r r-knitr
 install:
   - pip install autopep8 pep8
-  - pip install .
+  - pip install .[all]
 
 # Cache isn't working yet because problems with expiration header. Disable for now because it's breaking builds.
 # cache: pip
@@ -32,4 +32,3 @@ before_script:
   - "pep8 --exclude knowledge_repo/app/migrations,build --ignore=E501 ."
 script:
   - bash run_tests.sh
-

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ The Knowledge Repository project is focussed on facilitating the sharing of know
 
 1\. Install the knowledge-repo tooling
 ```
-pip install git+ssh://git@github.com/airbnb/knowledge-repo.git
+pip install git+ssh://git@github.com/airbnb/knowledge-repo.git[ipynb]
 ```
+
 2\. Initialize a knowledge repository - your posts will get added here
 ```
 knowledge_repo --repo ./example_repo init
@@ -88,10 +89,15 @@ There are two repositories associated with the Knowledge Repository project.
 1. This repository, which will be installed first. This is referred to as the knowledge repository tooling.
 2. A knowledge data repository, which is created second. This is where the knowledge posts are stored.
 
-### Installation of the knowledge repository tooling
-To install the knowledge repository tooling, simply run:
+### Installation
+To install the knowledge repository tooling (and all its dependencies), simply run:
 
-`pip install git+ssh://git@github.com/airbnb/knowledge-repo.git`
+`pip install git+ssh://git@github.com/airbnb/knowledge-repo.git[all]`
+
+You can also skip installing dependencies which are only required in special cases by replacing `all` with one or more of the following (separated by commas):
+- `ipynb` : Installs the dependencies required for adding/converting Jupyter notebook files
+- `pdf` : Installs the dependencies required for uploading PDFs using the web editor
+- `dev`: Installs the dependencies required for doing development, including running the tests
 
 The `knowledge_repo` script is the one that is used for all of the following actions. It requires the `--repo` flag to be passed to it, with the location of the knowledge data repository.
 

--- a/knowledge_repo/__init__.py
+++ b/knowledge_repo/__init__.py
@@ -1,11 +1,13 @@
 from ._version import *
+from .utils.dependencies import check_dependencies
+check_dependencies(__dependencies__)
 
-from .repository import KnowledgeRepository
-from .post import KnowledgePost
+from .repository import KnowledgeRepository  # nopep8
+from .post import KnowledgePost  # nopep8
 
-from . import converters
-from . import postprocessors
-from . import repositories
+from . import converters  # nopep8
+from . import postprocessors  # nopep8
+from . import repositories  # nopep8
 
-import logging
+import logging  # nopep8
 logging.basicConfig(level=logging.INFO)

--- a/knowledge_repo/_version.py
+++ b/knowledge_repo/_version.py
@@ -1,6 +1,6 @@
 import subprocess
 
-__all__ = ['__author__', '__author_email__', '__version__', '__git_uri__', '__dependencies__']
+__all__ = ['__author__', '__author_email__', '__version__', '__git_uri__', '__dependencies__', '__optional_dependencies__']
 
 __author__ = "Nikki Ray (maintainer), Robert Chang, Dan Frank,  Chetan Sharma,  Matthew Wardrop"
 __author_email__ = "nikki.ray@airbnb.com, robert.chang@airbnb.com, dan.frank@airbnb.com, chetan.sharma@airbnb.com, matthew.wardrop@airbnb.com"
@@ -11,16 +11,18 @@ except:
     pass
 __git_uri__ = "git@github.com:airbnb/knowledge-repo.git"
 
+# These are the core dependencies, and should include all packages needed for accessing repositories
+# and running a non-server-side instance of the flask application. Optional dependencies for converters/etc
+# should be defined elsewhere.
 __dependencies__ = [
     # Knowledge Repository Dependencies
-    'markdown',  # Markdown conversion utilities
-    'nbconvert',  # Jupyter notebook conversion utilities
-    'nbformat',  # Jupyter notebook reference format
-    'gitpython',  # Git abstraction
-    'pyyaml',  # Yaml parser and utilities
-    'tabulate',  # Rendering user information prettily
-    'enum34',  # Post status enum object
     'future',  # Python 2/3 support
+    'enum34',  # Python 3.4+ enum object used for Post status
+    'pyyaml',  # Yaml parser and utilities
+    'markdown',  # Markdown conversion utilities
+    'gitpython',  # Git abstraction
+    'tabulate',  # Rendering information prettily in knowledge_repo script
+
     # Flask App Dependencies
     'flask',  # Main flask framework
     'flask_mail',  # Mail client and utilities
@@ -30,10 +32,27 @@ __dependencies__ = [
     'werkzeug',  # Development webserver
     'gunicorn',  # Deployed webserver
     'inflection',  # String transformation library
-    'PyPDF2',  # image for parsing PDFs to images
-    'wand',  # imagemagick integration for image uploading
-    'Pillow',  # image processing for sending images
-    # Testing Dependencies
-    'nose',  # Testing framework
-    'beautifulsoup4'  # HTML/XML parser
 ]
+
+__optional_dependencies__ = {
+    # ipynb notebook conversion suport
+    'ipynb': [
+        'nbformat',
+        'nbconvert',
+        'traitlets'
+    ],
+
+    # PDF to image conversion used by app
+    'pdf': [
+        'PyPDF2',  # image for parsing PDFs to images
+        'wand',  # imagemagick integration for image uploading
+    ],
+
+    # Testing dependencies
+    'dev': [
+        'nose',  # Testing framework
+        'beautifulsoup4',  # HTML/XML parser
+        'coverage'  # Documentation coverage tester
+    ]
+}
+__optional_dependencies__['all'] = [dep for deps in __optional_dependencies__.values() for dep in deps]

--- a/knowledge_repo/app/utils/image.py
+++ b/knowledge_repo/app/utils/image.py
@@ -2,6 +2,9 @@ import imghdr
 import io
 import os
 
+from knowledge_repo.utils.dependencies import check_dependencies
+from knowledge_repo._version import __optional_dependencies__
+
 ALLOWED_IMAGE_TYPES = ('png', 'jpeg', 'gif')
 
 
@@ -26,6 +29,7 @@ def pdf_page_to_png(src_pdf, pagenum=0, resolution=154):
     :param int resolution: Resolution for resulting png in DPI.
     """
 
+    check_dependencies(__optional_dependencies__['pdf'])
     # Import libraries within this function so as to avoid import-time dependence
     import PyPDF2
     from wand.image import Image  # TODO: When we start using this again, document which system-level libraries are required.

--- a/knowledge_repo/converter.py
+++ b/knowledge_repo/converter.py
@@ -5,6 +5,7 @@ from functools import wraps
 
 from .postprocessor import KnowledgePostProcessor
 from .utils.registry import SubclassRegisteringABCMeta
+from .utils.dependencies import check_dependencies
 from future.utils import with_metaclass
 
 
@@ -20,12 +21,17 @@ class KnowledgePostConverter(with_metaclass(SubclassRegisteringABCMeta, object))
     _registry_keys = None  # File extensions
 
     def __init__(self, kp, format=None, postprocessors=None, **kwargs):
+        check_dependencies(self.dependencies, "Whoops! You are missing some dependencies required to use `{}` instances.".format(self.__class__.__name__))
         self.kp = kp
         self.format = format
         if postprocessors is None:
             postprocessors = ['extract_images', 'format_checks']
         self.postprocessors = postprocessors
         self.init(**kwargs)
+
+    @property
+    def dependencies(self):
+        return []
 
     def init(self):
         pass

--- a/knowledge_repo/converters/ipynb.py
+++ b/knowledge_repo/converters/ipynb.py
@@ -1,10 +1,7 @@
 import os
-import nbformat
-from nbconvert import MarkdownExporter
-from jinja2 import DictLoader
-from traitlets.config import Config
 
 from ..converter import KnowledgePostConverter
+from .._version import __optional_dependencies__
 
 TEMPLATE = '''
 {%- extends 'markdown.tpl' -%}
@@ -36,7 +33,15 @@ TEMPLATE = '''
 class IpynbFormat(KnowledgePostConverter):
     _registry_keys = ['ipynb']
 
+    @property
+    def dependencies(self):
+        return __optional_dependencies__['ipynb']
+
     def from_file(self, filename):
+        import nbformat
+        from nbconvert import MarkdownExporter
+        from jinja2 import DictLoader
+        from traitlets.config import Config
 
         c = Config()
         # c.ExtractOutputPreprocessor.extract_output_types = set()

--- a/knowledge_repo/converters/stub.py
+++ b/knowledge_repo/converters/stub.py
@@ -7,6 +7,11 @@ class StubConverter(KnowledgePostConverter):
     '''
     _registry_keys = None
 
+    @property
+    def dependencies(self):
+        # Dependencies required for this converter on top of core knowledge-repo dependencies
+        return []
+
     def from_file(self, filename, **opts):
         raise NotImplementedError
 

--- a/knowledge_repo/utils/dependencies.py
+++ b/knowledge_repo/utils/dependencies.py
@@ -1,0 +1,17 @@
+import pkg_resources
+
+
+def check_dependencies(dependencies, message=None):
+    missing_deps = []
+    for dep in dependencies:
+        try:
+            pkg_resources.get_distribution(dep)
+        except:
+            missing_deps.append(dep)
+    if missing_deps:
+        message = message or "Whoops! You do not seem to have all the dependencies required."
+        fix = ("You can fix this by running:\n\n"
+               "\t{install_command}\n\n"
+               "Note: Depending on your system's installation of Python, you may "
+               "need to use `pip2` or `pip3` instead of `pip`.").format(install_command='pip install --upgrade ' + ' '.join(missing_deps))
+        raise RuntimeError('\n\n'.join([message, fix]))

--- a/scripts/knowledge_repo
+++ b/scripts/knowledge_repo
@@ -13,7 +13,6 @@ import shutil
 import argparse
 import subprocess
 from tabulate import tabulate
-import pkg_resources
 
 # Register handler for SIGTERM, so we can run cleanup code if we are terminated
 signal.signal(signal.SIGTERM, lambda signum, frame: sys.exit(0))
@@ -26,22 +25,6 @@ if os.path.exists(os.path.join(os.path.dirname(script_dir), 'knowledge_repo', '_
     sys.path.insert(0, os.path.join(script_dir, '..'))
 import knowledge_repo  # nopep8
 from knowledge_repo.repositories.gitrepository import GitKnowledgeRepository  # nopep8
-
-# Check if all dependencies are installed
-missing_deps = []
-for dep in knowledge_repo.__dependencies__:
-    try:
-        pkg_resources.get_distribution(dep)
-    except:
-        missing_deps.append(dep)
-if missing_deps:
-    print("Whoops! The knowledge_repo tool has been updated and you are missing "
-          "some of the required dependencies. You can fix this by running:\n\n"
-          "\tpip install --upgrade " + " ".join(missing_deps) + "\n\n"
-          "Note: Depending on your system's installation of Python, you may "
-          "need to use `pip2` or `pip3` instead of `pip`."
-          )
-    sys.exit(1)
 
 # If there's a contrib folder, add this as well and import it
 contrib_dir = os.path.join(os.path.dirname(__file__), os.pardir, 'contrib')

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
     include_package_data=True,  # See included paths in MANIFEST.in
     scripts=['scripts/knowledge_repo'],
     install_requires=version_info['__dependencies__'],
+    extras_require=version_info['__optional_dependencies__'],
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Console',
@@ -73,9 +74,5 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 2.7',
     ],
-    extras_require={
-        'all': ['coverage'],
-        'dev': ['coverage'],
-    },
     cmdclass={'install_scripts': install_scripts_windows_wrapper}
 )


### PR DESCRIPTION
Currently users of the `knowledge_repo` script need to install a lot of libraries they may not need, and which (depending on context) can be difficult to install (for example, if they require C compilation or other utilities like image-magick installed). This patch makes these optional, while retaining ease of their installation.
