### PR TITLE
Update version to 0.6, and fix classifiers.

### DIFF
--- a/knowledge_repo/_version.py
+++ b/knowledge_repo/_version.py
@@ -4,7 +4,7 @@ __all__ = ['__author__', '__author_email__', '__version__', '__git_uri__', '__de
 
 __author__ = "Nikki Ray (maintainer), Robert Chang, Dan Frank,  Chetan Sharma,  Matthew Wardrop"
 __author_email__ = "nikki.ray@airbnb.com, robert.chang@airbnb.com, dan.frank@airbnb.com, chetan.sharma@airbnb.com, matthew.wardrop@airbnb.com"
-__version__ = "0.5"
+__version__ = "0.6"
 try:
     __version__ += '_' + subprocess.check_output(['git', 'rev-parse', 'HEAD'], shell=False).decode('utf-8').replace('\n', '')
 except:

--- a/setup.py
+++ b/setup.py
@@ -67,12 +67,17 @@ setup(
     install_requires=version_info['__dependencies__'],
     extras_require=version_info['__optional_dependencies__'],
     classifiers=[
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 4 - Beta',
         'Environment :: Console',
         'Environment :: Web Environment',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
+        'Intended Audience :: Information Technology',
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5'
     ],
     cmdclass={'install_scripts': install_scripts_windows_wrapper}
 )


### PR DESCRIPTION
This updates the classifier fields to their correct values, including changing the referenced license from MIT to Apache Software License. Bumps version to 0.6.
