### PR TITLE
Fix knowledge_repo deploy, MetaKnowledgeRepository missing _kp_uuid, and add a common *.uris method for KnowledgeRepository instances.

### DIFF
--- a/knowledge_repo/app/app.py
+++ b/knowledge_repo/app/app.py
@@ -155,9 +155,10 @@ class KnowledgeFlask(Flask):
             return response
 
         @self.context_processor
-        def webeditng_enabled():
-            repos = self.config.get('REPOS')
-            return {"webeditor_enabled": 'webposts' in repos if repos else False}
+        def webediting_enabled():
+            # TODO: Link this more to KnowledgeRepository capability and
+            # configuration rather than a specific name.
+            return {"webeditor_enabled": 'webposts' in current_repo.uris}
 
     @property
     def repository(self):

--- a/knowledge_repo/repositories/meta.py
+++ b/knowledge_repo/repositories/meta.py
@@ -102,6 +102,9 @@ class MetaKnowledgeRepository(KnowledgeRepository):
         prefix, repository, repo_path = self.__repo_for_path(path)
         return '{{{prefix}}}{repository_uri}'.format(prefix=prefix, repository_uri=repository._kp_repository_uri(repo_path))
 
+    def _kp_uuid(self, path):
+        return self.__delegate_for_path(path, '_kp_uuid')
+
     def _kp_exists(self, path, revision=None):
         return self.__delegate_for_path(path, '_kp_exists', revision=revision)
 

--- a/scripts/knowledge_repo
+++ b/scripts/knowledge_repo
@@ -254,8 +254,7 @@ if args.action in ['preview', 'runserver']:
     app = repo.get_app(debug=args.debug,
                        db_uri=args.dburi,
                        config=args.config,
-                       REPOSITORY_INDEXING_ENABLED=(args.action == 'runserver'),
-                       REPOS=args.repo)
+                       REPOSITORY_INDEXING_ENABLED=(args.action == 'runserver'))
 
     if args.action == 'preview':
         kp_path = repo._kp_path(args.path)
@@ -309,7 +308,7 @@ elif args.action == 'deploy':
 import sys
 sys.path.insert(0, '{}')
 import knowledge_repo
-app = knowledge_repo.KnowledgeRepository.for_uri({}).get_app(db_uri={}, debug={}, config={}, REPOS={})
+app = knowledge_repo.KnowledgeRepository.for_uri({}).get_app(db_uri={}, debug={}, config={})
         '''.format(kr_path, uris, db_uri, str(args.debug),
                    '"' + os.path.abspath(args.config) + '"' if args.config is not None else "None",
                    args.repo))


### PR DESCRIPTION
This fixes an old hack to get repository uris into the app, in the process fixing gunicorn deploy. It also adds the _kp_uuid method dispatcher for MetaKnowledgeRepository, to again support multiple repositories.