### PR TITLE
[Logging] Remove logging for typeahead

### DIFF
--- a/knowledge_repo/app/routes/render.py
+++ b/knowledge_repo/app/routes/render.py
@@ -158,6 +158,5 @@ def about():
 
 
 @blueprint.route('/ajax_post_typeahead', methods=['GET', 'POST'])
-@PageView.logged
 def ajax_post_typehead():
     return json.dumps(current_app.config.get('typeahead_data', {}))


### PR DESCRIPTION
Another one line fix - there's no reason to log an action that's not instantiated by the user, and that also clutters up the logs 

@earthmancash @matthewwardrop @danfrankj 