### PR TITLE
Suppress spurious git fatal messages when not running in a git repository.

### DIFF
--- a/knowledge_repo/_version.py
+++ b/knowledge_repo/_version.py
@@ -6,7 +6,8 @@ __author__ = "Nikki Ray (maintainer), Robert Chang, Dan Frank,  Chetan Sharma,  
 __author_email__ = "nikki.ray@airbnb.com, robert.chang@airbnb.com, dan.frank@airbnb.com, chetan.sharma@airbnb.com, matthew.wardrop@airbnb.com"
 __version__ = "0.6.1"
 try:
-    __version__ += '_' + subprocess.check_output(['git', 'rev-parse', 'HEAD'], shell=False).decode('utf-8').replace('\n', '')
+    with open(os.devnull, 'w') as devnull:
+        __version__ += '_' + subprocess.check_output(['git', 'rev-parse', 'HEAD'], shell=False, stderr=devnull).decode('utf-8').replace('\n', '')
 except:
     pass
 __git_uri__ = "git@github.com:airbnb/knowledge-repo.git"


### PR DESCRIPTION
Currently the `knowledge_repo` script checks to see if it is in a git checked out copy of the knowledge-repo repository, and if so appends the git revision to the version number. If not running in a git repository, this results in a spurious "fatal" error. Suppressing stderr from this command solves the problem, as in this patch.