### PR TITLE
[Feature] Allow update endpoint

### DIFF
--- a/knowledge_repo/app/proxies.py
+++ b/knowledge_repo/app/proxies.py
@@ -2,4 +2,5 @@ from flask import current_app
 from werkzeug.local import LocalProxy
 
 db_session = LocalProxy(lambda: current_app.db.session)
+background_db_session = LocalProxy(lambda: current_app.db.session)
 current_repo = LocalProxy(lambda: current_app.repository)

--- a/knowledge_repo/app/routes/render.py
+++ b/knowledge_repo/app/routes/render.py
@@ -159,4 +159,5 @@ def about():
 
 @blueprint.route('/ajax_post_typeahead', methods=['GET', 'POST'])
 def ajax_post_typehead():
-    return json.dumps(current_app.config.get('typeahead_data', {}))
+    with current_app.typeahead_lock:
+        return json.dumps(current_app.config.get('typeahead_data', {}))

--- a/resources/server_config.py
+++ b/resources/server_config.py
@@ -17,6 +17,9 @@ DB_AUTO_CREATE = True
 # performed using `knowledge_repo --repo <> db_upgrade ...`.
 DB_AUTO_UPGRADE = False
 
+# Interval, in seconds, between refreshes of the typeahead index. A value less than or equal to 0
+# means "never refresh", i.e. only populate the typeahead index at startup.
+TYPEAHEAD_UPDATE_PERIOD_SEC = 600
 
 # ---------------------------------------------------
 # Repository configuration
@@ -36,6 +39,8 @@ DB_AUTO_UPGRADE = False
 # For example, if your server instance is sitting atop
 # a meta-repository, it may make sense to update the meta-repository
 # configuration with that of one of its children.
+
+
 def prepare_repo(repo):
     return repo
 


### PR DESCRIPTION
This is the original PR from @yolken to fix #48 

PR Additions: 
Creates an `/update` endpoint that users can hit to force an update of the index-data
Adds a setting in the server_config that sets how often the typeahead is refreshed

PTAL: @matthewwardrop @danfrankj @earthmancash 
