### PR TITLE
[Feature] Make sure excluded tags are excluded everywhere

### DIFF
--- a/knowledge_repo/app/routes/render.py
+++ b/knowledge_repo/app/routes/render.py
@@ -68,6 +68,10 @@ def render():
     if not post:
         raise Exception("unable to find post at {}".format(path))
 
+    if post.contains_excluded_tag:
+        # It's possilbe that someone gets a direct link to a post that has an excluded tag
+        return render_template("error.html")
+
     html = render_post(post)
     raw_post = render_post_raw(post) if raw else None
 

--- a/knowledge_repo/app/utils/emails.py
+++ b/knowledge_repo/app/utils/emails.py
@@ -14,9 +14,6 @@ from ..utils.render import render_post
 
 logger = logging.getLogger(__name__)
 
-# TODO move me to config
-TAGS_EXCLUDED_FROM_SUBSCRIPTION_EMAILS = ['other/private', 'private']
-
 
 def usernames_to_emails(usernames):
     username_to_email = current_repo.config.username_to_email
@@ -62,7 +59,7 @@ def send_subscription_emails(post):
     # if this post is tagged as private - send no emails
     post_full_tags = [tag.name for tag in post.tags]
     for full_tag in post_full_tags:
-        if full_tag in TAGS_EXCLUDED_FROM_SUBSCRIPTION_EMAILS:
+        if full_tag in current_app.config.get("EXCLUDED_TAGS"):
             return
     for tag in post.tags:
         send_subscription_email(post, tag)

--- a/resources/server_config.py
+++ b/resources/server_config.py
@@ -83,3 +83,11 @@ USER_GROUP_TO_PROJECT = {}  # TODO: Deprecate?
 # WEB_EDITOR_PREFIXES to a list of supported path prefixes.
 # e.g. ['webposts', 'projects']
 WEB_EDITOR_PREFIXES = ['webposts']
+
+
+# ---------------------------------------------------
+# Tag configuration
+# ---------------------------------------------------
+# Posts with certain tags can be excluded from showing up
+# in the app. This can be useful for security purposes
+EXCLUDED_TAGS = ['private']

--- a/tests/config_server.py
+++ b/tests/config_server.py
@@ -88,3 +88,10 @@ MAIL_DEFAULT_SENDER = "knowledge_editors"  # default = None
 # WEB_EDITOR_PREFIXES to a list of supported path prefixes.
 # e.g. ['webposts', 'projects']
 WEB_EDITOR_PREFIXES = None
+
+# ---------------------------------------------------
+# Tag configuration
+# ---------------------------------------------------
+# Posts with certain tags can be excluded from showing up
+# in the app. This can be useful for security purposes
+EXCLUDED_TAGS = ['private']


### PR DESCRIPTION
While we have the concept of excluded tags, the tags and the posts weren't being excluded everywhere. This PR makes sure that all posts with excluded tags are hidden from everywhere. 

Test Plan: 
Add a "private" tag to the post and make sure it is not visible in any route

PTAL @matthewwardrop @danfrankj @earthmancash 
