### PR TITLE
Two trivial fixes: one for initialising a newly checked out repository with the embedded tooling, and one for updating the database when a KnowledgeRepository backend gains the capability of registering UUIDs.

### DIFF
--- a/knowledge_repo/app/index.py
+++ b/knowledge_repo/app/index.py
@@ -35,7 +35,7 @@ def update_index():
         kp = kr_dir.pop(post.path)
 
         # Update metadata of post if required
-        if (kp.revision > post.revision or not post.is_published):
+        if (kp.revision > post.revision or not post.is_published or kp.uuid != post.uuid):
             if kp.is_valid():
                 logger.info('Recording update to post at: {}'.format(kp.path))
                 post.update_metadata_from_kp(kp)

--- a/knowledge_repo/repositories/gitrepository.py
+++ b/knowledge_repo/repositories/gitrepository.py
@@ -141,7 +141,10 @@ class GitKnowledgeRepository(KnowledgeRepository):
                     break
         if sm is not None:
             sm_target_url = sm.config_reader().get_value('url')
-            sm_actual_url = sm.module().git.config('--get', 'remote.origin.url')
+            try:
+                sm_actual_url = sm.module().git.config('--get', 'remote.origin.url')
+            except git.InvalidGitRepositoryError:
+                sm_actual_url = "the uninitialized state"
             if sm_target_url != sm_actual_url:
                 logging.info('Migrating embedded tooling from {} to {}.'.format(sm_actual_url, sm_target_url))
                 self.git.git.submodule('sync')


### PR DESCRIPTION
Currently the knowledge_repo script fails to initialise the embedded tools in a newly checked out repository due to dependence on metadata in the (non-existent) submodule. This patch fixes this. It also adds support for updating the index when the UUID of a post changes from NULL.