### PR TITLE
Use https rather than git protocol to both install and embed tooling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Check out this [Medium Post](https://medium.com/airbnb-engineering/scaling-knowl
 
 1\. Install the knowledge-repo tooling
 ```
-pip install git+ssh://git@github.com/airbnb/knowledge-repo.git[ipynb]
+pip install  --upgrade "git+https://github.com/airbnb/knowledge-repo.git@stable#egg=knowledge_repo[ipynb]"
 ```
 
 2\. Initialize a knowledge repository - your posts will get added here

--- a/knowledge_repo/_version.py
+++ b/knowledge_repo/_version.py
@@ -10,7 +10,7 @@ try:
         __version__ += '_' + subprocess.check_output(['git', 'rev-parse', 'HEAD'], shell=False, stderr=devnull).decode('utf-8').replace('\n', '')
 except:
     pass
-__git_uri__ = "git@github.com:airbnb/knowledge-repo.git"
+__git_uri__ = "https://github.com/airbnb/knowledge-repo.git"
 
 # These are the core dependencies, and should include all packages needed for accessing repositories
 # and running a non-server-side instance of the flask application. Optional dependencies for converters/etc


### PR DESCRIPTION
Currently we have been using the ssh protocol to both install and setup the embedded tooling for knowledge_repo, which was required during the closed beta; but is now causing difficulties for people who have not set up public key authentication with Github. This patch solves this by using the https protocol.

Closes #57 .