### PR TITLE
Fix encoding errors when using reading images from files in extract_images in Python 3.

### DIFF
--- a/knowledge_repo/postprocessors/extract_images.py
+++ b/knowledge_repo/postprocessors/extract_images.py
@@ -64,7 +64,7 @@ class ExtractImages(KnowledgePostProcessor):
     def copy_image(cls, kp, path, is_ref=False):
         if is_ref:
             return
-        with open(path) as f:
+        with open(path, 'rb') as f:
             kp.write_image(os.path.basename(path), f.read())
         return os.path.join('images', os.path.basename(path))
 


### PR DESCRIPTION
Fixes #75 . The addition of the binary flag works on Python 2 also, where it serves as documentation.