### PR TITLE
check for NoneType in EXCLUDED_TAGS

### DIFF
--- a/knowledge_repo/app/models.py
+++ b/knowledge_repo/app/models.py
@@ -312,9 +312,10 @@ class Post(db.Model):
     @property
     def contains_excluded_tag(self):
         excluded_tags = current_app.config.get('EXCLUDED_TAGS')
-        for tag in self.tags:
-            if tag.name in excluded_tags:
-                return True
+        if excluded_tags is not None:
+            for tag in self.tags:
+                if tag.name in excluded_tags:
+                    return True
         return False
 
     _status = db.Column('status', db.Integer(), default=0)


### PR DESCRIPTION
With a fresh install, and the ipynb example from the readme, the error is:

```
lib/python3.5/site-packages/sqlalchemy/sql/default_comparator.py:161: SAWarning: 
  The IN-predicate on "tags.name" was invoked with an empty sequence. This results in a contradiction, 
   which nonetheless can be expensive to evaluate.  Consider alternative strategies for improved 
   performance.
  'strategies for improved performance.' % expr)
```

The reason is that currently the EXCLUDED_TAGS reference is only set in the test folder (in the config_server.py file). This means that running the app outside of a test context will start up the application with no excluded tags, and it will fail. 

This patch checks to prevent a NoneType comparison in case when there are no excluded tags yet.

_Please note_: I'm not sure if this is the intended behaviour though, and if not,  then we need to set the EXCLUDED_TAGS = ['private'] in the app.py config section. This may the case if you intend files with the private tag to be excluded by default.
