### PR TITLE
[Search] Add keyword search + ranking

### DIFF
--- a/knowledge_repo/app/index.py
+++ b/knowledge_repo/app/index.py
@@ -3,6 +3,7 @@ import logging
 from .proxies import db_session, current_repo
 from .models import Post
 from .utils.emails import send_subscription_emails
+from .utils.search import get_keywords
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -28,6 +29,10 @@ def update_index():
             logger.info('Recording unpublished status for post at {}'.format(post.path))
             post.status = current_repo.PostStatus.UNPUBLISHED
             continue
+
+        # TODO(nikki_ray): This is to support the backfilling of this column. Remove this.
+        if not post.keywords:
+            post.keywords = get_keywords(post)
 
         # Update database according to current state of existing knowledge post and
         # remove from kp_dir. This means that when this loop finishes, kr_dir will

--- a/knowledge_repo/app/models.py
+++ b/knowledge_repo/app/models.py
@@ -15,6 +15,7 @@ from knowledge_repo._version import __version__
 from knowledge_repo.repository import KnowledgeRepository
 from .proxies import current_repo, db_session
 from .utils.models import unique_constructor
+from .utils.search import get_keywords
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.ext.orderinglist import ordering_list
 from sqlalchemy.ext.associationproxy import association_proxy
@@ -445,7 +446,9 @@ class Post(db.Model):
         self.revision = kp.revision
         self.title = headers['title']
         self.tldr = headers['tldr']
-        self.keywords = ",".join(headers.get('keywords', []))
+        self.authors = headers.get('authors', [])
+        self.tags = headers.get('tags', [])
+        self.keywords = get_keywords(self)
         self.thumbnail = kp.thumbnail_uri
 
         self.created_at = headers['created_at']
@@ -453,8 +456,6 @@ class Post(db.Model):
         if self.created_at > self.updated_at:
             self.updated_at = self.created_at
 
-        self.authors = headers.get('authors', [])
-        self.tags = headers.get('tags', [])
         self.status = kp.status
 
 

--- a/knowledge_repo/app/templates/base.html
+++ b/knowledge_repo/app/templates/base.html
@@ -104,61 +104,36 @@
     {% block scripts %}
     <script type='text/javascript'>
     $("#searchbar")[0].setSelectionRange(1000, 1000);
-    var substringMatcher = function(pageMeta) {
-      return function findMatches(q, cb) {
-        var matches, substringRegex;
 
-        // an array that will be populated with substring matches
-        matches = [];
-
-        // regex used to determine if a string contains the substring `q`
-        substrRegex = new RegExp(q, 'i');
-
-        // iterate through the pool of strings and for any string that
-        // contains the substring `q`, add it to the `matches` array
-        $.each(pageMeta, function(i, meta) {
-          var match = false;
-          if (substrRegex.test(meta.title)) {
-            match = true;
-          };
-          if (substrRegex.test(meta.author)) {
-            match = true;
-          };
-          if (match) {
-            matches.push(meta);
-          }
-        });
-
-        cb(matches);
-      };
-    };
-
-
-    $.get('/ajax_post_typeahead', function(typeahead_post_info) {
-      typeahead_post_info = JSON.parse(typeahead_post_info);
-      $('#searchbar').typeahead({
-          hint: false,
-          highlight: true,
-          minLength: 1
+    $('#searchbar').typeahead({
+        hint: false,
+        highlight: true,
+        minLength: 1
+      },
+      {
+        name: 'knowledge_posts',
+        limit: 10,
+        display: function (item) {
+          return item;
         },
-        {
-          name: 'knowledge_posts',
-          display: function (item) {
-            return item.title;
-          },
-          templates: {
-            empty: Handlebars.compile(
-              '<div class="tt-not-found">' +
-                'Unable to find any posts that match the current query' +
-                '</div>'
-            ),
-            suggestion: function(data) {
-              return '<p><strong class="text-rausch">' + data.author + '</strong> – ' + data.title + '</p>';
-            }
-          },
-          source: substringMatcher(typeahead_post_info)
+        templates: {
+          empty: Handlebars.compile(
+            '<div class="tt-not-found">' +
+              'Unable to find any posts that match the current query' +
+              '</div>'
+          ),
+          suggestion: function(data) {
+            return '<p style="overflow-wrap:break-word"><strong class="text-rausch">' + data.title + '</strong> – ' + data.author + '</p>';
+          }
+        },
+        source: function(q, sync, async) {
+          $.ajax('/ajax_post_typeahead?search=' + q,
+          {
+            success: function(data,status){ async(JSON.parse(data)); }
+          })
         }
-    );
+      });
+
 
     $('#searchbar').bind('typeahead:select', function(obj, datum, name) {
       window.location = '/render?markdown=' + encodeURIComponent(datum.path);
@@ -174,8 +149,6 @@
 
     var padding = $('.tt-menu').outerWidth()
     $('.tt-menu').width($('#searchbar').width() + padding + "px")
-    });
-
 
     </script>
     {% endblock %}

--- a/knowledge_repo/app/utils/search.py
+++ b/knowledge_repo/app/utils/search.py
@@ -1,0 +1,34 @@
+"""Functions that deal with getting the "keywords" for typeahead search
+
+  Ultimately, this file will include all functions related to search. At the moment,
+  it has two purposes:
+    1. To hardcode the list of nltk stopwords in English
+    2. Create a list of keywords from a list of words
+"""
+ENGLISH_STOPWORDS = [u'i', u'me', u'my', u'myself', u'we', u'our', u'ours', u'ourselves',
+                     u'you', u'your', u'yours', u'yourself', u'yourselves', u'he', u'him',
+                     u'his', u'himself', u'she', u'her', u'hers', u'herself', u'it', u'its',
+                     u'itself', u'they', u'them', u'their', u'theirs', u'themselves', u'what',
+                     u'which', u'who', u'whom', u'this', u'that', u'these', u'those', u'am',
+                     u'is', u'are', u'was', u'were', u'be', u'been', u'being', u'have', u'has',
+                     u'had', u'having', u'do', u'does', u'did', u'doing', u'a', u'an', u'the',
+                     u'and', u'but', u'if', u'or', u'because', u'as', u'until', u'while',
+                     u'of', u'at', u'by', u'for', u'with', u'about', u'against', u'between',
+                     u'into', u'through', u'during', u'before', u'after', u'above', u'below',
+                     u'to', u'from', u'up', u'down', u'in', u'out', u'on', u'off', u'over',
+                     u'under', u'again', u'further', u'then', u'once', u'here', u'there',
+                     u'when', u'where', u'why', u'how', u'all', u'any', u'both', u'each',
+                     u'few', u'more', u'most', u'other', u'some', u'such', u'no', u'nor',
+                     u'not', u'only', u'own', u'same', u'so', u'than', u'too', u'very',
+                     u's', u't', u'can', u'will', u'just', u'don', u'should', u'now']
+
+
+def get_keywords(post):
+    " Given a post object return a space-separated string of keywords "
+    author = [author.format_name for author in post.authors]
+    title = post.title.split(" ")
+    tldr = post.tldr.split(" ")
+    tags = [tag.name for tag in post.tags]
+    full_search_text = author + title + tldr + tags
+    keywords = ' '.join([word for word in full_search_text if word not in ENGLISH_STOPWORDS])
+    return keywords


### PR DESCRIPTION
@matthewwardrop @danfrankj @earthmancash 

The much awaited search ranking PR. What this does: 
1. Actually fills in the keywords column, by combining the author, title, tldr, and tags of a post, and removing stopwords. 
2. Use the typeahead search to create a SQL statement where we rank the search results by the number of search terms that are present in the keywords of a post. Note: current limitation, right now, if a term like "nights" appears 4 times in one post, and 2 times in another post, those are considered equal. 
3. The typeahead front end is the same. 

Once this lands, I'll create a new tag and push out a release
@akuhn as an FYI