### PR TITLE
[Search] Show title on mouse down + add background color

### DIFF
--- a/knowledge_repo/app/static/css/custom.css
+++ b/knowledge_repo/app/static/css/custom.css
@@ -16,6 +16,10 @@
  cursor:pointer;
 }
 
+.tt-suggestion.tt-cursor {
+  background-color: #f5f5f5;
+}
+
 .tt-input, .tt-hint {
   width: 250px;
 }

--- a/knowledge_repo/app/templates/base.html
+++ b/knowledge_repo/app/templates/base.html
@@ -114,7 +114,7 @@
         name: 'knowledge_posts',
         limit: 10,
         display: function (item) {
-          return item;
+          return item.title + " - " + item.author;
         },
         templates: {
           empty: Handlebars.compile(


### PR DESCRIPTION
The title is pretty self explanatory - on the new typeahead search, there was a regression where if you pressed the down arrow, you saw `[object object]` in the search box, as opposed to the title, so I fixed that + added a background color on the mouse down so you could see which suggestion you were currently at. 

Test Plan:
Write in the search box and make sure a title shows up + background color exists when you use the arrow keys to scroll

@earthmancash @matthewwardrop @danfrankj 
