### PR TITLE
Improve logic around deployment of the knowledge repo.

### DIFF
--- a/knowledge_repo/app/deploy/__init__.py
+++ b/knowledge_repo/app/deploy/__init__.py
@@ -1,0 +1,4 @@
+from .common import KnowledgeDeployer, get_app_builder
+from .flask import FlaskDeployer
+from .gunicorn import GunicornDeployer
+from .uwsgi import uWSGIDeployer

--- a/knowledge_repo/app/deploy/common.py
+++ b/knowledge_repo/app/deploy/common.py
@@ -1,0 +1,86 @@
+import os
+import types
+import inspect
+import textwrap
+from abc import abstractmethod
+from future.utils import with_metaclass
+
+from knowledge_repo import KnowledgeRepository
+from knowledge_repo.utils.registry import SubclassRegisteringABCMeta
+
+
+def get_app_builder(uris, debug, db_uri, config, **kwargs):
+    def get_app():
+        return KnowledgeRepository.for_uri(uris).get_app(db_uri=db_uri, debug=debug, config=config, **kwargs)
+    return get_app
+
+
+class KnowledgeDeployer(with_metaclass(SubclassRegisteringABCMeta, object)):
+
+    def __init__(self,
+                 knowledge_builder,
+                 host='0.0.0.0',
+                 port=7000,
+                 workers=4,
+                 timeout=60):
+        assert isinstance(knowledge_builder, (str, types.FunctionType)), "Unknown builder type {}".format(type(knowledge_builder))
+        self.knowledge_builder = knowledge_builder
+        self.host = host
+        self.port = port
+        self.workers = workers
+        self.timeout = timeout
+
+    @classmethod
+    def using(cls, engine):
+        return cls._get_subclass_for(engine)
+
+    @property
+    def builder_str(self):
+        if isinstance(self.knowledge_builder, types.FunctionType):
+            out = []
+            for nl, cell in zip(self.knowledge_builder.__code__.co_freevars, self.knowledge_builder.__closure__):
+                if isinstance(cell.cell_contents, str):
+                    out.append('{} = "{}"'.format(nl, cell.cell_contents.replace('"', '\\"')))
+                else:
+                    out.append('{} = {}'.format(nl, cell.cell_contents))
+            out.append(textwrap.dedent(inspect.getsource(self.knowledge_builder)))
+            return '\n'.join(out)
+        return self.knowledge_builder
+
+    @property
+    def builder_func(self):
+        if isinstance(self.knowledge_builder, str):
+            knowledge_builder = 'def get_app():\n\t' + self.knowledge_builder.replace('\n', '\t') + '\n\treturn app'
+            namespace = {}
+            exec(knowledge_builder, namespace)
+            return namespace['get_app']
+        return self.knowledge_builder
+
+    @property
+    def app(self):
+        return self.builder_func()
+
+    def write_temp_files(self):
+        import tempfile
+        tmp_dir = tempfile.mkdtemp()
+        tmp_path = os.path.join(tmp_dir, 'server.py')
+
+        kr_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..'))
+
+        out = []
+        out.append('import sys')
+        out.append('sys.path.insert(0, "{}")'.format(kr_path))
+        out.append('import knowledge_repo')
+
+        out.append(self.builder_str)
+        if not isinstance(self.knowledge_builder, str):
+            out.append('app = %s()' % self.knowledge_builder.__name__)
+
+        with open(tmp_path, 'w') as f:
+            f.write('\n'.join(out))
+
+        return tmp_dir
+
+    @abstractmethod
+    def run(self):
+        raise NotImplementedError

--- a/knowledge_repo/app/deploy/flask.py
+++ b/knowledge_repo/app/deploy/flask.py
@@ -1,0 +1,16 @@
+from .common import KnowledgeDeployer
+
+
+class FlaskDeployer(KnowledgeDeployer):
+
+    _registry_keys = ['flask']
+
+    def run(self, **kwargs):
+        app = self.app
+        return app.run(
+            debug=app.config['DEBUG'],
+            host=self.host,
+            port=self.port,
+            threaded=app.supports_threads,
+            **kwargs
+        )

--- a/knowledge_repo/app/deploy/gunicorn.py
+++ b/knowledge_repo/app/deploy/gunicorn.py
@@ -1,0 +1,38 @@
+""" gunicorn.py
+
+    Utilities for running the knowledge app via gunicorn.
+
+    Adapted from example in http://docs.gunicorn.org/en/stable/custom.html.
+"""
+
+from __future__ import absolute_import
+
+from gunicorn.app.base import BaseApplication
+
+from .common import KnowledgeDeployer
+
+
+class GunicornDeployer(BaseApplication, KnowledgeDeployer):
+
+    _registry_keys = ['gunicorn']
+
+    def __init__(self, *args, **kwargs):
+        KnowledgeDeployer.__init__(self, *args, **kwargs)
+        BaseApplication.__init__(self)
+
+    def load_config(self):
+        options = {
+            'bind': '{}:{}'.format(self.host, self.port),
+            'workers': self.workers,
+            'timeout': self.timeout
+        }
+        for key, value in options.items():
+            self.cfg.set(key, value)
+
+    def load(self):
+        return self.builder_func()
+
+    def run(self):
+        if not self.app.supports_threads:
+            raise RuntimeError("Database configuration is not suitable for deployment (not thread-safe).")
+        return BaseApplication.run(self)

--- a/knowledge_repo/app/deploy/uwsgi.py
+++ b/knowledge_repo/app/deploy/uwsgi.py
@@ -1,0 +1,36 @@
+import os
+import subprocess
+import logging
+import shutil
+
+from .common import KnowledgeDeployer
+
+logger = logging.getLogger()
+
+
+class uWSGIDeployer(KnowledgeDeployer):
+
+    _registry_keys = ['uwsgi']
+
+    COMMAND = "uwsgi --http {socket} --plugin python --wsgi-file {path} --callable app --master --processes {processes} --threads {threads} --uid --gid"
+
+    def run(self):
+        if not self.app.supports_threads:
+            raise RuntimeError("Database configuration is not suitable for deployment (not thread-safe).")
+
+        tmp_dir = self.write_temp_files()
+
+        config = {
+            'socket': '{}:{}'.format(self.host, self.port),
+            'processes': self.workers,
+            'threads': 2,
+            'timeout': self.timeout,
+            'path': os.path.join(tmp_dir, 'server.py')
+        }
+
+        try:
+            cmd = "cd {};".format(tmp_dir) + self.COMMAND.format(**config)
+            logger.info("Starting server with command:  " + " ".join(cmd))
+            subprocess.check_output(cmd, shell=True)
+        finally:
+            shutil.rmtree(tmp_dir)

--- a/knowledge_repo/app/routes/index.py
+++ b/knowledge_repo/app/routes/index.py
@@ -149,7 +149,7 @@ def render_cluster():
                          post in tag.posts
                          if post.is_published and not post.contains_excluded_tag]
             if tag_posts:
-                tags_to_posts[tag.name] = tag.posts
+                tags_to_posts[tag.name] = tag_posts
         tuples = [(k, v) for (k, v) in tags_to_posts.items()]
 
     elif group_by == "folder":

--- a/scripts/knowledge_repo
+++ b/scripts/knowledge_repo
@@ -179,6 +179,7 @@ deploy.add_argument('-w', '--workers', default=4, type=int, help="Number of guni
 deploy.add_argument('-t', '--timeout', default=60, type=int, help="Specify the timeout (seconds) for the gunicorn web server")
 deploy.add_argument('-db', '--dburi', help='The SQLAlchemy database uri.')
 deploy.add_argument('-c', '--config', default=None, help="The config file from which to read server configuration.")
+deploy.add_argument('--engine', default='gunicorn', help='Which server engine to use when deploying; choose from: "flask", "gunicorn" (default) or "uwsgi".')
 
 db_upgrade = subparsers.add_parser('db_upgrade', help='Upgrade the database to the latest schema. Only necessary if you have disabled automatic migrations in your deployment.')
 db_upgrade.set_defaults(action='db_upgrade')
@@ -257,12 +258,14 @@ if args.action in ['submit', 'push'] or (args.action == 'add' and args.submit):
     sys.exit(0)
 
 # Everything below this point has to do with running and/or managing the web app
+from knowledge_repo.app.deploy import KnowledgeDeployer, get_app_builder
 
 if args.action in ['preview', 'runserver']:
-    app = repo.get_app(debug=args.debug,
-                       db_uri=args.dburi,
-                       config=args.config,
-                       REPOSITORY_INDEXING_ENABLED=(args.action == 'runserver'))
+    app_builder = get_app_builder(args.repo,
+                                  debug=args.debug,
+                                  db_uri=args.dburi,
+                                  config=args.config,
+                                  REPOSITORY_INDEXING_ENABLED=(args.action == 'runserver'))
 
     if args.action == 'preview':
         kp_path = repo._kp_path(args.path)
@@ -270,65 +273,28 @@ if args.action in ['preview', 'runserver']:
         url = 'http://127.0.0.1:{}/render?markdown={}'.format(args.port, kp_path)
         threading.Timer(1.25, lambda: webbrowser.open(url)).start()
 
-    use_reloader = args.debug and args.action == 'runserver'
-    threaded = True
-    # Check if in-memory databases are being used, and if so, avoid using threading
-    uris = []
-    def get_uris(uri):
-        if isinstance(uri, str):
-            uris.append(uri)
-            return
-        elif isinstance(uri, knowledge_repo.KnowledgeRepository):
-            get_uris(uri.uri)
-        elif isinstance(uri, dict):
-            for u in uri.values():
-                get_uris(u)
-    get_uris(repo)
-    for u in itertools.chain(uris, [app.config['SQLALCHEMY_DATABASE_URI']]):
-        if ':memory:' in u or u.startswith('sqlite://:'):
-            use_reloader = False
-            threaded = False
-            break
-
-    app.run(debug=args.debug,
-            host='0.0.0.0',
-            port=args.port,
-            use_reloader=use_reloader,
-            threaded=threaded)
-
+    KnowledgeDeployer.using('flask')(
+        app_builder,
+        host='0.0.0.0',
+        port=args.port
+    ).run(
+        use_reloader=args.debug and args.action == 'runserver'
+    )
 
 elif args.action == 'deploy':
-    import tempfile
-    tmp_dir = tempfile.mkdtemp()
-    tmp_path = os.path.join(tmp_dir, 'server.py')
+    app_builder = get_app_builder(args.repo,
+                                  debug=args.debug,
+                                  db_uri=args.dburi,
+                                  config=args.config)
 
-    kr_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-
-    if isinstance(repo.uri, str):
-        uris = "'{}'".format(repo.uri.replace("'", "\\'"))
-    else:
-        uris = str({prefix: repo.uri for prefix, repo in repo.uri.items()})
-
-    db_uri = "'{}'".format(args.dburi.replace("'", "\\'")) if isinstance(args.dburi, str) else str(args.dburi)
-
-    with open(tmp_path, 'w') as f:
-        f.write('''
-import sys
-sys.path.insert(0, '{}')
-import knowledge_repo
-app = knowledge_repo.KnowledgeRepository.for_uri({}).get_app(db_uri={}, debug={}, config={})
-        '''.format(kr_path, uris, db_uri, str(args.debug),
-                   '"' + os.path.abspath(args.config) + '"' if args.config is not None else "None",
-                   args.repo))
-
-    try:
-        # Run gunicorn server
-        cmd = "cd {}; gunicorn -w {} --timeout {} -b 0.0.0.0:{} server:app"
-        cmd = cmd.format(tmp_dir, args.workers, args.timeout, args.port)
-        # logger.info("Starting server with command:  " + " ".join(cmd))
-        subprocess.check_output(cmd, shell=True)
-    finally:
-        shutil.rmtree(tmp_dir)
+    server = KnowledgeDeployer.using(args.engine)(
+        app_builder,
+        host='0.0.0.0',
+        port=args.port,
+        workers=args.workers,
+        timeout=args.timeout
+    )
+    server.run()
 
 elif args.action == 'db_upgrade':
     app = repo.get_app(db_uri=args.dburi, debug=args.debug, config=args.config)


### PR DESCRIPTION
This patch set improves the deployment process, in part based on work by @yolken. Where possible, it does not write out temporary files but instead just launches gunicorn from within-process. This is useful when trying to compile knowledge_repo into a standalone executable format (such as pex).

This solves #97.