### PR TITLE
Show version of knowledge repo showing content.

### DIFF
--- a/knowledge_repo/_version.py
+++ b/knowledge_repo/_version.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 
 __all__ = ['__author__', '__author_email__', '__version__', '__git_uri__', '__dependencies__', '__optional_dependencies__']

--- a/knowledge_repo/app/app.py
+++ b/knowledge_repo/app/app.py
@@ -10,6 +10,7 @@ from flask_migrate import Migrate
 from alembic import command
 from alembic.migration import MigrationContext
 
+import knowledge_repo
 from .proxies import db_session, current_repo
 from .index import update_index
 from .models import db as sqlalchemy_db, Post, User, Tag
@@ -150,6 +151,14 @@ class KnowledgeFlask(Flask):
             # TODO: Link this more to KnowledgeRepository capability and
             # configuration rather than a specific name.
             return {"webeditor_enabled": 'webposts' in current_repo.uris}
+
+        @self.context_processor
+        def inject_version():
+            version = knowledge_repo.__version__
+            version_revision = None
+            if '_' in knowledge_repo.__version__:
+                version, version_revision = version.split('_')
+            return dict(version=version, version_revision=version_revision)
 
     @property
     def repository(self):

--- a/knowledge_repo/app/static/css/custom.css
+++ b/knowledge_repo/app/static/css/custom.css
@@ -50,6 +50,14 @@
   width: 250px;
 }
 
+/* footer elements */
+
+.footer {
+    text-align: center;
+    color: #565a5c;
+    padding: 20px;
+}
+
 .panel {
   border: 1px solid #dce0e0;
   color: #565a5c;

--- a/knowledge_repo/app/templates/base.html
+++ b/knowledge_repo/app/templates/base.html
@@ -99,6 +99,10 @@
 
      </div>
 
+  <div class="footer">
+      Served with ♥ by <a href="https://github.com/airbnb/knowledge-repo">Knowledge Repo</a> <a title='{{version_revision}}' href="https://github.com/airbnb/knowledge-repo/releases/tag/v{{ version }}">{{ version }}</a>
+  </div>
+
     </body>
 
     {% block scripts %}


### PR DESCRIPTION
This was something we discussed earlier, and which I think looks classy.

<img width="1144" alt="screen shot 2016-11-01 at 12 03 51 am" src="https://cloud.githubusercontent.com/assets/124910/19882012/a6212b7c-9fc7-11e6-98da-83231f1fdda9.png">

Clicking `Knowledge Repo` takes you to this github repository. Clicking the version shows takes you to that version's release notes. Hovering over the version shows you the current git revision, if running out of a git repository.

@NiharikaRay @earthmancash @danfrankj 