### PR TITLE
added ability to have proxy posts

### DIFF
--- a/knowledge_repo/converters/html.py
+++ b/knowledge_repo/converters/html.py
@@ -90,9 +90,14 @@ class HTMLConverter(KnowledgePostConverter):
         if images_base64_encode:
             urlmappers.insert(0, self.base64_encode_image_mapper)
 
+        # proxy posts are assumed to be embeddable links
+        if 'proxy' in self.kp.headers:
+            return '<iframe width=100% height=100% src="{}"></iframe>'.format(self.kp.headers['proxy'].strip())
+
         html = ''
         if not skip_headers:
             html += self.render_headers()
+
         html += markdown.Markdown(extensions=MARKDOWN_EXTENSTIONS).convert(self.kp.read())
 
         return self.apply_url_remapping(html, urlmappers)


### PR DESCRIPTION
one of my favorite one-line changes... 

@matthewwardrop @NiharikaRay @earthmancash 

Markdown files that have a proxy key are rendered as proxy posts

![image](https://cloud.githubusercontent.com/assets/616139/19911757/d98a71ae-a052-11e6-8b08-1b23154a5d0e.png)


![image](https://cloud.githubusercontent.com/assets/616139/19911754/cfd968ae-a052-11e6-9f62-d395d9c27fb7.png)


