### PR TITLE
refactor of webeditor code

### DIFF
--- a/knowledge_repo/app/index.py
+++ b/knowledge_repo/app/index.py
@@ -40,7 +40,7 @@ def update_index():
         kp = kr_dir.pop(post.path)
 
         # Update metadata of post if required
-        if (kp.revision > post.revision or not post.is_published or kp.uuid != post.uuid):
+        if (post.revision is None or kp.revision > post.revision or not post.is_published or kp.uuid != post.uuid):
             if kp.is_valid():
                 logger.info('Recording update to post at: {}'.format(kp.path))
                 post.update_metadata_from_kp(kp)

--- a/knowledge_repo/app/templates/email_templates/review_email.txt
+++ b/knowledge_repo/app/templates/email_templates/review_email.txt
@@ -2,7 +2,7 @@
 
 They said "{{ comment_text }}"
 
-Link to post: {{ request.base_url }}/posteditor?post_id={{ post_id }}
+Link to post: {{ request.base_url }}/posteditor?path={{ path }}
 
 Regards,
 

--- a/knowledge_repo/app/templates/email_templates/reviewer_request_email.txt
+++ b/knowledge_repo/app/templates/email_templates/reviewer_request_email.txt
@@ -1,6 +1,6 @@
 You've been asked to review a knowledge post!
 
-Link to post: {{ request.base_url }}/posteditor?post_id={{ post_id }}
+Link to post: {{ request.base_url }}/posteditor?path={{ path }}
 
 There is a comment section at the bottom where you can leave your feedback. Once the review is done, ping one of the Knowledge Editors, and they can publish the post.
 

--- a/knowledge_repo/app/templates/post_editor.html
+++ b/knowledge_repo/app/templates/post_editor.html
@@ -14,7 +14,7 @@
       width:100% !important;
     }
 
-    #post_project {
+    #post_path {
       vertical-align:inherit !important;
     }
 
@@ -114,21 +114,23 @@
                    value="{{ title if title else '' }}"></input>
             <br>
 
-            <label for="post_author"> Author </label>
+            <label for="post_author"> Authors </label>
             <select id="post_author"
                     class="js-example-tags form-control"
                     type="text"
                     multiple
                     data-tags='true'>
-              <option value='{{username}}'> {{username}} </option>
+              <option value='{{ username }}'> {{ username }} </option>
             </select>
             <br>
 
-            <label for="post_project"> Project </label>
-            <input id="post_project"
+            <br>
+
+            <label for="post_path"> Path </label>
+            <input id="post_path"
                    class="form-control typeahead"
                    type="text"
-                   value="{{ project if project else '' }}"></input>
+                   value="{{ path if path else '' }}"></input>
             <br>
 
             <label for="post_image_feed"> Feed Image</label>
@@ -275,7 +277,7 @@
 {% block scripts %}
 {{ super() }}
 <script>
-var all_form_fields = ['#post_title', '#post_project',
+var all_form_fields = ['#post_title', '#post_path',
                        '#post_created_at', '#post_updated_at',
                        '#post_author', '#post_image_feed', '#post_tags']
 
@@ -316,20 +318,20 @@ var substringMatcher = function(pageMeta) {
   };
 };
 
-$.get('/ajax_projects_typeahead', function(typeahead_projects_info) {
-    typeahead_projects_info = JSON.parse(typeahead_projects_info);
-    $('#post_project').typeahead({
+$.get('/ajax_paths_typeahead', function(paths) {
+    paths = JSON.parse(paths);
+    $('#post_path').typeahead({
       hint: false,
       highlight: true,
       minLength: 1,
-      value: '{{ project if project else '' }}'
+      value: '{{ path if path else '' }}'
     },
     {
-      name: 'Projects',
+      name: 'Paths',
       display: function (item) {
         return item;
       },
-      source: substringMatcher(typeahead_projects_info)
+      source: substringMatcher(paths)
     }
   );
 });
@@ -344,12 +346,8 @@ $.get('/ajax_tags_typeahead', function(typeahead_tags_info) {
   });
 
   var tags_default_text =  "Tags are in the form: #tag_type/tag_name. Start typing to see suggestions!"
-  var tags = '{{ tags if tags else '' }}'
-  var tags_in_list = tags.split(",")
+  var tags_in_list = {{ tags|safe }}
 
-  $.each(tags_in_list, function(i,v){
-    tags_in_list[i] = v.trim()
-  });
 
   $('#post_tags').select2({
     placeholder: tags_default_text
@@ -395,10 +393,9 @@ $.get('/ajax_users_typeahead', function(typeahead_users_info){
     }
   })
   var authors_default_text =  "Users contributing to the post."
-  var authors = '{{ author if author else '' }}'
-  var authors_in_list = authors.split(",")
-  $.each(authors_in_list, function(i,v){
-    authors_in_list[i] = v.trim()
+  var authors = {{ authors |safe}}
+  $.each(authors, function(i,v){
+    authors[i] = v.trim()
   });
 
   $('#post_author').select2({
@@ -406,7 +403,7 @@ $.get('/ajax_users_typeahead', function(typeahead_users_info){
   });
 
   $("#post_author").select2()
-                   .val(authors_in_list)
+                   .val(authors)
                    .trigger("change")
 })
 
@@ -495,17 +492,17 @@ $(submission_close).on("click", function(){
     dataType: "json",
     data: JSON.stringify(data),
     contentType: 'application/json',
-    url: '/submit?post_id={{ post_id }}',
+    url: '/submit?path={{ path }}',
     async: true,
     success:function(response_data){
       alert("The status has been changed!")
-      window.location = '/posteditor?post_id={{ post_id }}'
+      window.location = '/posteditor?path={{ path }}'
     },
     error: function(response_data){
       console.log("ERROR")
       console.log(JSON.stringify(response_data))
       if (response_data['status'] == 200){
-        window.location = '/posteditor?post_id={{ post_id }}'
+        window.location = '/posteditor?path={{ path }}'
       } else {
         alert("Your post wasn't submitted for review, please try again!")
       }
@@ -520,10 +517,10 @@ if ( status == 2 || status == 3 ) {
     var publish_button_text = publish_button.textContent.trim();
     var url = '';
     if (publish_button_text == "Unpublish"){
-      url = '/unpublish_post?post_id={{ post_id }}';
+      url = '/unpublish_post?path={{ path }}';
       alert_text = 'Your post has been unpublished!';
     } else {
-      url = '/publish_post?post_id={{post_id}}';
+      url = '/publish_post?path={{ path }}';
       alert_text = "Your post has been published!";
     }
 
@@ -547,8 +544,8 @@ if ( status == 2 || status == 3 ) {
 var author_publish_checkbox = $("#author_can_publish")[0]
 $(author_publish_checkbox).on("click", function(){
   var checked = this.can_approve;
-  var url = "/author_publish";
-  url += "?post_id={{post_id}}"
+  var url = "/accept_post";
+  url += "?path={{ path }}"
   $.ajax({
     type: "POST",
     contentType: "application/json",
@@ -556,7 +553,7 @@ $(author_publish_checkbox).on("click", function(){
     async: true,
     success: function(response_data){
       alert("The publishing status was changed!");
-      window.location = '/posteditor?post_id={{ post_id }}';
+      window.location = '/posteditor?path={{ path }}';
     },
     error: function(response_data){
       alert("The publishing status was NOT changed");
@@ -568,7 +565,9 @@ $(save_button).on("click", function(){
   save_button.setAttribute("class", "btn btn-large btn-primary");
   var error = false;
   var title = $("#post_title")[0].value;
-  var project = $('#post_project').typeahead('val');
+  var path = $('#post_path').typeahead('val');
+
+
   // Currently, the tags from the post_tags are in a list
   var tags = $("#post_tags").select2().val()
   var tldr = $("#post_tldr")[0].value;
@@ -578,7 +577,7 @@ $(save_button).on("click", function(){
   var markdown = $("#post_text")[0].value;
   var feed_image = $("#post_image_feed")[0].value;
 
-  if (title === '' || project === '' || tags === null ||
+  if (title === '' || path === '' || tags === null ||
       tldr === '' || author === null || markdown === ''){
     alert("One of the fields was left empty! Your post was not saved, please try again")
     error = true;
@@ -625,7 +624,7 @@ $(save_button).on("click", function(){
 
     postContent = {
       'title': title,
-      'project': project,
+      'path': path,
       'feed_image': feed_image,
       'tags': tags,
       'tldr': tldr,
@@ -643,7 +642,7 @@ $(save_button).on("click", function(){
           dataType: "json",
           data: JSON.stringify(postContent),
           contentType: "application/json",
-          url: '/save_post?post_id={{ post_id }}',
+          url: '/save_post',
           async: true,
           success: function(response_data) {
             if (response_data['success'] == 0) {
@@ -651,9 +650,9 @@ $(save_button).on("click", function(){
             }
             else {
               save_button.setAttribute("class", "btn btn-large");
-              var post_id = response_data['post_id']
+              var path = response_data['path']
               alert("The post was successfully saved!")
-              window.location = '/posteditor?post_id=' + post_id
+              window.location = '/posteditor?path=' + path
             }
           },
           error: function(response_data) {
@@ -671,7 +670,7 @@ $(save_button).on("click", function(){
 function deleteReview(commentId) {
   $.ajax({
       type: "GET",
-      url: '/delete_review?post_id={{ post_id|urlencode }}&comment_id=' + commentId,
+      url: '/delete_review?path={{ path|urlencode }}&comment_id=' + commentId,
       async: false
   });
   location.reload();
@@ -690,7 +689,7 @@ function postReview() {
       dataType: "json",
       data: JSON.stringify(postContent),
       contentType: "application/json",
-      url: '/review?post_id={{ post_id|urlencode }}',
+      url: '/review?path={{ path|urlencode }}',
       async: false
   });
   location.reload();
@@ -845,7 +844,7 @@ function refreshRenderedMarkdown() {
   });
 
 
-  $("#post_project")[0].setSelectionRange(1000, 1000);
+  $("#post_path")[0].setSelectionRange(1000, 1000);
 
 
 // uploads images dropped in the textbox, and returns the marked-down links
@@ -915,4 +914,3 @@ $("#post_text").on("drop", function (event) {
 </script>
 
 {% endblock %}
-

--- a/knowledge_repo/app/utils/emails.py
+++ b/knowledge_repo/app/utils/emails.py
@@ -154,32 +154,32 @@ def send_internal_error_email(subject_line, **kwargs):
     current_app.config['mail'].send(msg)
 
 
-def send_reviewer_request_email(post_id, reviewer):
+def send_reviewer_request_email(path, reviewer):
     if 'mail' not in current_app.config:
         logger.warning('Mail subsystem is not configured. Silently dropping email.')
         return
     subject = "Someone requested a web post review from you!"
     msg = Message(subject, [reviewer])
     msg.body = render_template("email_templates/reviewer_request_email.txt",
-                               post_id=post_id)
+                               path=path)
     current_app.config['mail'].send(msg)
 
 
-def send_review_email(post_id, comment_text, commenter='Someone'):
+def send_review_email(path, comment_text, commenter='Someone'):
     if 'mail' not in current_app.config:
         logger.warning('Mail subsystem is not configured. Silently dropping email.')
         return
-    webpost = (db_session.query(Post)
-               .filter(Post.id == post_id)
-               .first())
-    post_title = webpost.title
-    authors = [author.username for author in webpost.authors]
+
+    kp = current_repo.post(path)
+    headers = kp.headers
+    post_title = headers['title']
+    authors = headers['authors']
     post_author_emails = usernames_to_emails(authors)
-    subject = "Someone reviewed your web post!"
+    subject = "Someone reviewed your post!"
     msg = Message(subject, post_author_emails)
     msg.body = render_template("email_templates/review_email.txt",
                                commenter=commenter,
                                comment_text=comment_text,
                                post_title=post_title,
-                               post_id=post_id)
+                               path=path)
     current_app.config['mail'].send(msg)

--- a/knowledge_repo/post.py
+++ b/knowledge_repo/post.py
@@ -61,7 +61,7 @@ def setup_yaml():
     def dict_constructor(loader, node):
         return collections.OrderedDict(loader.construct_pairs(node))
 
-    yaml.add_representer(collections.OrderedDict, dict_representer)
+    yaml.SafeDumper.add_representer(collections.OrderedDict, dict_representer)
     yaml.add_constructor(_mapping_tag, dict_constructor)
 
 
@@ -244,7 +244,7 @@ class KnowledgePost(object):
         if headers is not None:
             md = re.sub('^---\n[\s\S]+?---\n', '', md, count=1)
             md = '---\n' + \
-                yaml.dump(headers, default_flow_style=False) + '---\n' + md
+                yaml.safe_dump(headers, default_flow_style=False) + '---\n' + md
         md += '\n'
 
         self._write_ref('knowledge.md', encode(md))

--- a/knowledge_repo/repositories/dbrepository.py
+++ b/knowledge_repo/repositories/dbrepository.py
@@ -98,11 +98,10 @@ class DbKnowledgeRepository(KnowledgeRepository):
                 yield prefix
 
     # -------------- Post submission / addition user flow --------------------
-
-    def _add_prepare(self, kp, path, update=False):
+    def _add_prepare(self, kp, path, update=False, **kwargs):
         pass
 
-    def _add_cleanup(self, kp, path, update=False):
+    def _add_cleanup(self, kp, path, update=False, **kwargs):
         self.__set_post_status(path, self.PostStatus.DRAFT, kp.revision)
 
     def _submit(self, path):  # Submit a post for review

--- a/knowledge_repo/repositories/meta.py
+++ b/knowledge_repo/repositories/meta.py
@@ -23,7 +23,8 @@ class MetaKnowledgeRepository(KnowledgeRepository):
             if path.startswith(prefix):
                 relpath = posixpath.relpath(path, prefix or '.') if path else ''
                 return prefix, self.uri[prefix], relpath if relpath != '.' else None
-        raise ValueError("No KnowledgeRepository found for '{}'.".format(path))
+        raise ValueError(("No KnowledgeRepository found for '{}', "
+                          "paths must be prefixed with {}.").format(path, path_prefixes))
 
     def __distribute_method(self, method, **kwargs):
         return {name: getattr(repo, method)(**kwargs) for name, repo in list(self.uri.items())}

--- a/knowledge_repo/repository.py
+++ b/knowledge_repo/repository.py
@@ -142,6 +142,8 @@ class KnowledgeRepository(with_metaclass(SubclassRegisteringABCMeta, object)):
     # -------------- Post retrieval methods --------------------------------------
 
     def post(self, path, revision=None):
+        if path is None:
+            raise ValueError("path is None")
         path = self._kp_path(path)
         if not self.has_post(path, revision=revision) and path in self.config.aliases:
             path = self.config.aliases[path]
@@ -156,7 +158,7 @@ class KnowledgeRepository(with_metaclass(SubclassRegisteringABCMeta, object)):
         else:
             prefixes = prefix
         assert all([prefix is None or isinstance(prefix, str) for prefix in prefixes]), "All path prefixes must be strings."
-        prefixes = [prefix if prefix is None else posixpath.relpath(prefix, '/') for prefix in prefixes]
+        prefixes = [prefix if prefix is None else posixpath.relpath(prefix) for prefix in prefixes]
         if isinstance(status, str):
             if status == 'all':
                 status = [self.PostStatus.DRAFT, self.PostStatus.SUBMITTED, self.PostStatus.PUBLISHED, self.PostStatus.UNPUBLISHED]

--- a/tests/test_emails.py
+++ b/tests/test_emails.py
@@ -1,8 +1,8 @@
 import unittest
-
+import datetime
 from sqlalchemy import and_
 
-from knowledge_repo import KnowledgeRepository
+from knowledge_repo import KnowledgeRepository, KnowledgePost
 from knowledge_repo.app.models import Post, Subscription, Email, User
 from knowledge_repo.app.utils.emails import send_internal_error_email, send_subscription_emails, send_comment_email, send_review_email
 from knowledge_repo.app.proxies import db_session
@@ -12,69 +12,68 @@ class EmailTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(self):
+
         self.repo = KnowledgeRepository.for_uri('tests/test_repo', auto_create=True)
         self.app = self.repo.get_app(config='tests/config_server.py')
         self.app.repository.config.editors = ['knowledge_editors']
         self.client = self.app.test_client()
 
         self.knowledge_username = 'email_test_user'
-        # this creates a user
+        self.post_path = 'tests/test_email_functionality'
+        kp = KnowledgePost(self.post_path)
+
+        headers = {'title': 'Test Email Functionality',
+                   'authors': [self.knowledge_username],
+                   'tags': ['test_tag'],
+                   'tldr': 'This is the test tldr for the post',
+                   'created_at': datetime.date.today(),
+                   'updated_at': datetime.date.today()}
+        kp.write(md='Test Text', headers=headers)
+        self.repo.add(kp, message='test commit message')
+
+        # manual re-index
         with self.app.app_context():
-            User(username=self.knowledge_username)
-
-            web_post = Post(title='test_webpost')
-            git_post = (db_session.query(Post)
-                        .first())
-
-            db_session.add(web_post)
-            web_post.authors = ['test_author']
-
-            git_post.tags = ['test_tag']
-
+            post = Post()
+            db_session.add(post)
+            post.update_metadata_from_kp(kp)
             db_session.commit()
-
-            self.web_post_id = web_post.id
-            self.git_post_id = git_post.id
+            self.post_id = post.id
 
     def test01_review_email(self):
         """ Test Review Email """
-        commenter = 'test_commenter'
         comment_text = 'this is a test for review email'
         with self.app.app_context():
             with self.app.config['mail'].record_messages() as outbox:
                 with self.app.test_request_context():
-                    send_review_email(commenter=commenter,
+                    send_review_email(commenter='test_commenter',
                                       comment_text=comment_text,
-                                      post_id=self.web_post_id)
+                                      path=self.post_path)
 
-            web_post = (db_session.query(Post)
-                        .filter(Post.id == self.web_post_id)
-                        .first())
             assert len(outbox) == 1
-            assert outbox[0].subject == "Someone reviewed your web post!"
+            assert outbox[0].subject == "Someone reviewed your post!"
             # TODO assert format_commenter(commenter) in outbox[0].body
             assert comment_text in outbox[0].body
-            assert web_post.title in outbox[0].body
+
+            title = self.repo.post(self.post_path).headers['title']
+            assert title in outbox[0].body
 
     def test02_comment_email(self):
         """ Test Comment Email """
+        comment_text = 'this is a test for comment email'
         with self.app.app_context():
             with self.app.config['mail'].record_messages() as outbox:
                 with self.app.test_request_context():
-                    commenter = 'test_commenter'
-                    comment_text = 'this is a test for comment email'
-                    send_comment_email(commenter=commenter,
+                    send_comment_email(commenter='test_commenter',
                                        comment_text=comment_text,
-                                       post_id=self.git_post_id)
+                                       post_id=self.post_id)
 
-            git_post = (db_session.query(Post)
-                        .filter(Post.id == self.git_post_id)
-                        .first())
             assert len(outbox) == 1
             assert outbox[0].subject == "Someone commented on your post!"
             # assert format_commenter(commenter) in outbox[0].body
             assert comment_text in outbox[0].body
-            assert git_post.title in outbox[0].body
+
+            title = self.repo.post(self.post_path).headers['title']
+            assert title in outbox[0].body
 
     def test03_internal_error_email(self):
         """ Test Internal Error Email """
@@ -94,19 +93,17 @@ class EmailTest(unittest.TestCase):
                     editor_emails = [username_to_email(
                         editor) for editor in knowledge_editors]
                     assert sorted(outbox[0].recipients) == sorted(editor_emails)
-                    assert 'This email is for internal debugging only.' in outbox[
-                        0].body
+                    assert 'This email is for internal debugging only.' in outbox[0].body
 
     def test04_subscription_email(self):
         """ Test Subscription Email """
         # Subscribe to a tag from gitpost and webpost Note, don't send
         # a request to do it so that create_index() will happen later,
         # as it is before_first_request
+
         with self.app.app_context():
             db_session.expire_on_commit = False
-            git_post = (db_session.query(Post)
-                        .filter(Post.id == self.git_post_id)
-                        .first())
+            post = db_session.query(Post).get(self.post_id)
 
             user = User(username=self.knowledge_username)
             if user.id is None:
@@ -114,8 +111,8 @@ class EmailTest(unittest.TestCase):
             user_id = user.id
 
             # grab the first tag from the post
-            tag_id = git_post.tags[0].id
-            post_id = git_post.id
+            tag_id = post.tags[0].id
+            post_id = post.id
 
             subscription = Subscription(user_id=user_id, object_type='tag',
                                         object_id=tag_id)
@@ -126,27 +123,22 @@ class EmailTest(unittest.TestCase):
             # tag_to_subscribe
             with self.app.config['mail'].record_messages() as outbox:
                 with self.app.app_context():
-                    send_subscription_emails(git_post)
+                    send_subscription_emails(post)
 
             emails_sent = (db_session.query(Email)
-                           .filter(and_(Email.object_id == post_id,
-                                        Email.user_id == user_id,
-                                        Email.trigger_id == tag_id,
-                                        Email.trigger_type == 'subscription'))
-                           .all())
+                                     .filter(and_(Email.object_id == post_id,
+                                                  Email.user_id == user_id,
+                                                  Email.trigger_id == tag_id,
+                                                  Email.trigger_type == 'subscription'))
+                                     .all())
 
             # There should be exactly 1 email sent to the user for the target post
             # Check EmailSent records
             assert len(outbox) == 1, 'One subscription email should be actually sent'
-            assert len(
-                emails_sent) == 1, 'One subscription email should recorded as sent'
+            assert len(emails_sent) == 1, 'One subscription email should recorded as sent'
             # Check outbox of messages
-            assert len(
-                outbox[0].bcc) == 1, 'One subscription email should be actually sent to one user'
+            assert len(outbox[0].bcc) == 1, 'One subscription email should be actually sent to one user'
             assert "A knowledge post was just posted under tag" in outbox[0].body, 'Email should be the subscription email'
 
             username_to_email = self.app.repository.config.username_to_email
             assert outbox[0].bcc[0] == username_to_email(self.knowledge_username)
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/test_webeditorposts.py
+++ b/tests/test_webeditorposts.py
@@ -25,25 +25,23 @@ class WebEditorPostTest(unittest.TestCase):
         cls.app.config['DEBUG'] = True
         cls.client = cls.app.test_client()
 
-        cls.post_path = 'webeditor/misc/Test_Webeditor_Functionality'
+        cls.post_path = 'webeditor/misc/test_webeditor_functionality.kp'
         kp = KnowledgePost(cls.post_path)
 
         headers = {'title': 'Test Webeditor Functionality',
                    'authors': ['webeditor_test_user'],
-                   'project': 'test_project',
                    'tldr': 'This is the test tldr for the webpost.',
                    'created_at': datetime.date.today(),
                    'updated_at': datetime.date.today()}
-        md = 'Test Text'
-        kp.write(md=md, headers=headers)
+        kp.write(md='Test Text', headers=headers)
         cls.repo.add(kp)
 
+        # manual re-index
         with cls.app.app_context():
             post = Post()
             db_session.add(post)
             post.update_metadata_from_kp(kp)
             db_session.commit()
-
             cls.post_id = post.id
 
     def test01_webeditor_route(self):
@@ -84,7 +82,7 @@ class WebEditorPostTest(unittest.TestCase):
         filled out with the correct values
         """
 
-        rv = self.client.get('/posteditor?post_id={}'.format(self.post_id))
+        rv = self.client.get('/posteditor?path={}'.format(self.post_path))
         assert rv.status == "200 OK"
         data = rv.data.decode('utf-8')
         soup = BeautifulSoup(data, 'html.parser')
@@ -126,36 +124,26 @@ class WebEditorPostTest(unittest.TestCase):
         the relevant field is updated in the db
         """
         new_post_text = "Here is the new post_text"
-
         with self.app.app_context():
-            post = (db_session.query(Post)
-                              .filter(Post.id == self.post_id)
-                              .first())
 
-            str_created_at = datetime.datetime.strftime(post.created_at, '%Y-%m-%d')
-            str_updated_at = datetime.datetime.strftime(post.updated_at, '%Y-%m-%d')
-
-            post_json_object = {
-                'title': post.title,
-                'project': post.project,
-                'feed_image': "",  # TODO where do we store this?
-                'tags': "",  # TODO pass tags
-                'tldr': post.tldr,
-                'status': post.status.value,
-                'created_at': str_created_at,
-                'updated_at': str_updated_at,
-                'author': [auth.username for auth in post.authors],
-                'markdown': new_post_text
+            data = {
+                'title': "New Title",
+                'tags': ['New_Tag'],
+                'tldr': 'New TLDR',
+                'created_at': '1985-11-29',
+                'updated_at': '1985-11-29',
+                'author': ['webeditor_test_user'],
+                'markdown': new_post_text,
+                'path': self.post_path
             }
 
-            url = "/save_post?post_id=" + str(post.id)
-            rv = self.client.post(url,
-                                  data=json.dumps(post_json_object),
-                                  content_type='application/json')
+            rv = self.client.post("/save_post",
+                                  data=json.dumps(data),
+                                  content_type='application/json',
+                                  headers={'user_header': 'webeditor_test_user'})
             assert rv.status == "200 OK"
 
             kp = self.repo.post(self.post_path)
-
             assert kp.read(headers=False).strip() == new_post_text
 
     def test04_test_review_button(self):
@@ -165,13 +153,13 @@ class WebEditorPostTest(unittest.TestCase):
         And that going back to the form editor changes the button text
         And a review comment area is added
         """
-        rv = self.client.post('/submit?post_id={}'.format(self.post_id),
+        rv = self.client.post('/submit?path={}'.format(self.post_path),
                               data=json.dumps({'post_reviewers': 'test_post_reviewers'}),
                               content_type='application/json')
 
         assert rv.status == "200 OK"
 
-        rv = self.client.get('/posteditor?post_id={}'.format(self.post_id))
+        rv = self.client.get('/posteditor?path={}'.format(self.post_path))
 
         assert rv.status == "200 OK"
 
@@ -184,28 +172,22 @@ class WebEditorPostTest(unittest.TestCase):
         btn_in_review = soup.findAll("button", {"id": "btn_in_review"})
         assert btn_in_review and btn_in_review[0].text.strip() == "In Review Phase"
 
-        with self.app.app_context():
-            post = (db_session.query(Post)
-                              .filter(Post.id == self.post_id)
-                              .first())
-            assert post.status == self.repo.PostStatus.SUBMITTED
-
     def test05_test_author_can_publish_button(self):
-        """Test changing the permission for authors.
+        """Test accept post
 
         Clicking the author_can_publish checkbox
         should change the relevant field in the db
         """
-        url = "/author_publish?post_id=" + str(self.post_id)
-        rv = self.client.post(url)
-
+        rv = self.client.post("/accept_post?path={}".format(self.post_path))
         assert rv.status == "200 OK"
+
         with self.app.app_context():
-            post = (db_session.query(Post)
-                              .filter(Post.id == self.post_id)
-                              .first())
-            kp = self.repo.post(post.path)
+            kp = self.repo.post(self.post_path)
             assert kp.is_accepted is True
+
+            # TODO(Dan) after manually kick of re-index
+            # post = db_session.query(Post).get(self.post_id)
+            # assert post.status == self.repo.PostStatus.ACCEPTED
 
     def test06_test_publish_button(self):
         """Test the publish functionality.
@@ -217,16 +199,14 @@ class WebEditorPostTest(unittest.TestCase):
         and the button text
         """
         # test that clicking the publish button changes the status
-        rv = self.client.post('/publish_post?post_id={}'.format(self.post_id))
-
+        rv = self.client.post('/publish_post?path={}'.format(self.post_path))
         assert rv.status == "200 OK"
-        with self.app.app_context():
-            post = (db_session.query(Post)
-                              .filter(Post.id == self.post_id)
-                              .first())
-            assert post.status == self.repo.PostStatus.PUBLISHED
-            rv = self.client.get('/posteditor?post_id={}'.format(self.post_id))
 
+        with self.app.app_context():
+            kp = self.repo.post(self.post_path)
+            assert kp.is_published is True
+
+            rv = self.client.get('/posteditor?path={}'.format(self.post_path))
             assert rv.status == "200 OK"
 
             data = rv.data.decode("utf-8")
@@ -236,17 +216,14 @@ class WebEditorPostTest(unittest.TestCase):
             btn_publish = soup.findAll("button", {"id": "btn_publish"})
             assert btn_publish and btn_publish[0].text.strip() == "Unpublish"
 
-            rv = self.client.post('/unpublish_post?post_id={}'.format(self.post_id))
+            rv = self.client.post('/unpublish_post?path={}'.format(self.post_path))
             assert rv.status == "200 OK"
 
-            post = (db_session.query(Post)
-                              .filter(Post.id == self.post_id)
-                              .first())
+            # TODO(Dan) after manually kick of re-index
+            # post = db_session.query(Post).get(self.post_id)
+            # assert post.status == self.repo.PostStatus.UNPUBLISHED
 
-            assert post.status == self.repo.PostStatus.UNPUBLISHED
-
-            rv = self.client.get('/posteditor?post_id={}'.format(self.post_id))
-
+            rv = self.client.get('/posteditor?path={}'.format(self.post_path))
             assert rv.status == "200 OK"
 
             data = rv.data.decode("utf-8")
@@ -256,16 +233,15 @@ class WebEditorPostTest(unittest.TestCase):
             btn_publish = soup.findAll("button", {"id": "btn_publish"})
             assert btn_publish and btn_publish[0].text.strip() == "Publish"
 
+    @unittest.skip("post deletion not implemented")
     def test07_test_delete_button(self):
-        """Test webpost deletion."""
-        rv = self.client.get('/delete_post?post_id={}'.format(self.post_id))
+        """Test post deletion."""
+        rv = self.client.get('/delete_post?path={}'.format(self.post_id))
         assert rv.status == "200 OK"
 
         with self.app.app_context():
-            post = (db_session.query(Post)
-                              .filter(Post.id == self.post_id)
-                              .first())
-            assert not post
+            kp = self.repo.post(self.post_path)
+            assert kp.is_deleted is True
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
@matthewwardrop @NiharikaRay @earthmancash 

Refactor of webeditor flow including

 * use current_repo rather than Post() models to retrieve and manipulate posts 
 * allow users to specify which repo to submit a post to 
 * various cleanup 
 * security updates so you can't delete others posts / comments 

![image](https://cloud.githubusercontent.com/assets/616139/19946755/737465d6-a102-11e6-9680-3024e2d451d0.png)


TODOs 
* a few cases where we do need the post id to retrieve comments, etc. 
* testing
