### PR TITLE
[README] Add badges of pypi + build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # The Knowledge Repository (BETA)
+[![Build Status](https://travis-ci.org/airbnb/knowledge-repo.svg?branch=master)](https://travis-ci.org/airbnb/knowledge-repo)
+[![PyPI version](https://badge.fury.io/py/knowledge-repo.svg)](https://badge.fury.io/py/knowledge-repo)
+[![Python](https://img.shields.io/pypi/pyversions/knowledge-repo.svg?maxAge=2592000)](https://pypi.python.org/pypi/knowledge-repo)
 
 The Knowledge Repository project is focused on facilitating the sharing of knowledge between data scientists and other technical roles using data formats and tools that make sense in these professions. It provides various data stores (and utilities to manage them) for "knowledge posts", with a particular focus on notebooks (R Markdown and Jupyter / iPython Notebook) to better promote reproducible research.
 


### PR DESCRIPTION
While waiting for the other Travis Build to finish, I decided to add these badges to the top of the README. 

<img width="968" alt="screen shot 2016-11-02 at 5 16 33 pm" src="https://cloud.githubusercontent.com/assets/4268311/19952136/2d30f544-a120-11e6-9b79-96e17aefab57.png">

@earthmancash @matthewwardrop @danfrankj 