### PR TITLE
Fix bytes encoding bug between Python 2 and 3

### DIFF
--- a/knowledge_repo/app/utils/render.py
+++ b/knowledge_repo/app/utils/render.py
@@ -1,3 +1,5 @@
+import sys
+
 import markdown
 from flask import url_for
 from knowledge_repo.post import KnowledgePost
@@ -59,9 +61,14 @@ def render_post_header(post):
 
 def render_post_raw(post):
     if isinstance(post, KnowledgePost):
-        return post.read().encode('ascii', 'ignore')
+        raw_post = post.read().encode('ascii', 'ignore')
     else:
-        return post.text.encode('ascii', 'ignore')
+        raw_post = post.text.encode('ascii', 'ignore')
+
+    # NOTE: `str.encode()` returns a `bytes` object in Python 3
+    if sys.version_info.major >= 3:
+        return raw_post.decode('ascii', 'ignore')
+    return raw_post
 
 
 def render_post(post):


### PR DESCRIPTION
In Python 2, `str.encode()` returns an encoded `str`ing object, while in Python
3, the same call returns a `bytes` object. This mismatch causes display issues
on the "View Raw Markdown" page. (H/T @b11z)

On `master`:
![image](https://cloud.githubusercontent.com/assets/4246705/19986709/02662a90-a1d5-11e6-856e-755eaee246d6.png)

Post-PR:
![screen shot 2016-11-03 at 2 23 35 pm](https://cloud.githubusercontent.com/assets/4246705/19986721/0d03d128-a1d5-11e6-8bca-e67580401dde.png)