### PR TITLE
Attempt minor fix for knit Rmd into knowledge repo if system is windows

### DIFF
--- a/knowledge_repo/converters/rmd.py
+++ b/knowledge_repo/converters/rmd.py
@@ -22,7 +22,7 @@ class RmdConverter(KnowledgePostConverter):
                                                                     os.path.abspath(filename),
                                                                     tmp_path)
 
-            # Replace '\' with '\\' on Windows machines
+            # Replace '\' with '\\' on Windows machines so R happy with filepath
             if os.name == 'nt':
                 runcmd = runcmd.replace("\\", "\\\\")
 

--- a/knowledge_repo/converters/rmd.py
+++ b/knowledge_repo/converters/rmd.py
@@ -22,6 +22,7 @@ class RmdConverter(KnowledgePostConverter):
                                                                     os.path.abspath(filename),
                                                                     tmp_path)
 
+            # Replace '\' with '\\' on Windows machines
             if os.name == 'nt':
                 runcmd = runcmd.replace("\\", "\\\\")
 

--- a/knowledge_repo/converters/rmd.py
+++ b/knowledge_repo/converters/rmd.py
@@ -21,6 +21,9 @@ class RmdConverter(KnowledgePostConverter):
                         x = knit('{1}', '{2}', quiet=T)" """.format(os.path.abspath(os.path.dirname(filename)),
                                                                     os.path.abspath(filename),
                                                                     tmp_path)
+            if os.name == 'nt':
+                runcmd = runcmd.replace("\\", "\\\\")                                                        
+
             subprocess.check_output(runcmd, shell=True)
             Rmd_filename = tmp_path
 

--- a/knowledge_repo/converters/rmd.py
+++ b/knowledge_repo/converters/rmd.py
@@ -21,8 +21,9 @@ class RmdConverter(KnowledgePostConverter):
                         x = knit('{1}', '{2}', quiet=T)" """.format(os.path.abspath(os.path.dirname(filename)),
                                                                     os.path.abspath(filename),
                                                                     tmp_path)
+
             if os.name == 'nt':
-                runcmd = runcmd.replace("\\", "\\\\")                                                        
+                runcmd = runcmd.replace("\\", "\\\\")
 
             subprocess.check_output(runcmd, shell=True)
             Rmd_filename = tmp_path


### PR DESCRIPTION
Description of changeset: 

Added small change to creating a new post from an `Rmd` based on issue [109](https://github.com/airbnb/knowledge-repo/issues/109). Errors currently get thrown on Windows as the use of `os.path.abspath()` creates file paths using `\` on Windows. `R` doesn't like `\` and needs to have it escaped. Without doing so, the first `R` call inside knowledge_repo/converters/rmd.py to `setwd()` fails. 

I've added a small check that will replace all `\` with `\\` in the `runcmd` variable to try and correct for this if the `os.name` value returns `nt` (Windows). 

Test Plan: 


Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj

