### PR TITLE
bugfix to allow reindexing

### DIFF
--- a/knowledge_repo/app/index.py
+++ b/knowledge_repo/app/index.py
@@ -51,6 +51,7 @@ def update_index_required():
 
     seconds = seconds_since_index()
     seconds_check = seconds_since_index_check()
+
     if is_indexing() or (seconds is not None) and (seconds < 5 * 60) and (seconds_check < 5 * 60):
         return False
     try:

--- a/knowledge_repo/repositories/dbrepository.py
+++ b/knowledge_repo/repositories/dbrepository.py
@@ -64,7 +64,7 @@ class DbKnowledgeRepository(KnowledgeRepository):
 
     @property
     def revision(self):
-        return self.session.query(func.max(self.PostRef.created_at))
+        return self.session.query(func.max(self.PostRef.created_at)).first()[0]
 
     def update(self):
         pass


### PR DESCRIPTION
@matthewwardrop 

Previously current_repo.revisions returned a mapping from mountpoint to Repository object which can't be queried 