### PR TITLE
Support for different port numbers in git uris

### DIFF
--- a/knowledge_repo/repositories/gitrepository.py
+++ b/knowledge_repo/repositories/gitrepository.py
@@ -508,8 +508,8 @@ class GitKnowledgeRepository(KnowledgeRepository):
         if self.git_has_remote:
             m = re.match(r'^(.*?)?@([^/:]*):?(\d+)?', self.git_remote.url)
             if m:
-               if m.group(3):
-                  port = m.group(3)
+                if m.group(3):
+                    port = m.group(3)
         return port
 
     @property
@@ -517,7 +517,7 @@ class GitKnowledgeRepository(KnowledgeRepository):
         # TODO: support more types of hosts
         host = self.__remote_host
         port = self.__remote_port
-        
+
         if host:
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             s.settimeout(0.5)

--- a/knowledge_repo/repositories/gitrepository.py
+++ b/knowledge_repo/repositories/gitrepository.py
@@ -503,15 +503,26 @@ class GitKnowledgeRepository(KnowledgeRepository):
         return None
 
     @property
+    def __remote_port(self):
+        port = 22
+        if self.git_has_remote:
+            m = re.match(r'^(.*?)?@([^/:]*):?(\d+)?', self.git_remote.url)
+            if m:  # shorthand ssh uri
+               if m.group(3):
+                  port = m.group(3)
+        return port
+
+    @property
     def __remote_available(self):
         # TODO: support more types of hosts
         host = self.__remote_host
-
+        port = self.__remote_port
+        
         if host:
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             s.settimeout(0.5)
             try:
-                s.connect((socket.gethostbyname(host), 22))
+                s.connect((socket.gethostbyname(host), port))
                 return True
             except:
                 return False

--- a/knowledge_repo/repositories/gitrepository.py
+++ b/knowledge_repo/repositories/gitrepository.py
@@ -507,7 +507,7 @@ class GitKnowledgeRepository(KnowledgeRepository):
         port = 22
         if self.git_has_remote:
             m = re.match(r'^(.*?)?@([^/:]*):?(\d+)?', self.git_remote.url)
-            if m:  # shorthand ssh uri
+            if m:
                if m.group(3):
                   port = m.group(3)
         return port


### PR DESCRIPTION
Description of changeset: 
If your git repository is hosted on a different port than 22 you cannot connect to it using ssh.  This PR solves it by extracting the port number from the repository's URL. If no port is specified it defaults to 22. 

Test Plan: 
Testing regexp below, with and without a port number, without a port number it should return None, which the ___remote_port property would capture and in that case return 22.
```
git_remote_url = "ssh://git@some.domain.com:123/repo/project.git"
m = re.match(r'^(.*?)?@([^/:]*):?(\d+)?', git_remote_url)
print(m.group(3))


git_remote_url = "ssh://git@some.domain.com/repo/project.git"
m = re.match(r'^(.*?)?@([^/:]*):?(\d+)?', git_remote_url)
print(m.group(3))


git_remote_url = "https://git@some.domain.com/repo/project.git"
m = re.match(r'^(.*?)?@([^/:]*):?(\d+)?', git_remote_url)
print(m.group(3))

git_remote_url = "https://git@some.domain.com:123/repo/project.git"
m = re.match(r'^(.*?)?@([^/:]*):?(\d+)?', git_remote_url)
print(m.group(3))
```

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
