### PR TITLE
Convert all revisions to strings before comparison, and some neatening up of index logic.

### DIFF
--- a/knowledge_repo/app/app.py
+++ b/knowledge_repo/app/app.py
@@ -12,7 +12,7 @@ from alembic.migration import MigrationContext
 
 import knowledge_repo
 from .proxies import db_session, current_repo
-from .index import update_index, update_index_required, human_readable_time_since_index
+from .index import update_index, time_since_index, time_since_index_check
 from .models import db as sqlalchemy_db, Post, User, Tag
 from . import routes
 
@@ -142,7 +142,10 @@ class KnowledgeFlask(Flask):
             version_revision = None
             if '_' in knowledge_repo.__version__:
                 version, version_revision = version.split('_')
-            return dict(version=version, version_revision=version_revision, last_index=human_readable_time_since_index())
+            return dict(version=version,
+                        version_revision=version_revision,
+                        last_index=time_since_index(human_readable=True),
+                        last_index_check=time_since_index_check(human_readable=True))
 
     @property
     def repository(self):

--- a/knowledge_repo/app/templates/base.html
+++ b/knowledge_repo/app/templates/base.html
@@ -104,8 +104,8 @@
         </div>
 
         <div class="footer">
-            Served with ♥ by <a href="https://github.com/airbnb/knowledge-repo">Knowledge Repo</a> <a title='{{version_revision}}' href="https://github.com/airbnb/knowledge-repo/releases/tag/v{{ version }}">{{ version }}</a><br />
-            <i>Last indexed: {{last_index}}</i>
+            Served with <span class="glyphicon glyphicon-heart"></span> by <a href="https://github.com/airbnb/knowledge-repo">Knowledge Repo</a> <a {% if version_revision %}title='{{version_revision}}'{% endif %} href="https://github.com/airbnb/knowledge-repo/releases/tag/v{{ version }}">{{ version }}</a><br />
+            <i title="Last checked for updates: {{last_index_check}}">Last indexed: {{last_index}}</i>
         </div>
 
         {% block scripts %}

--- a/knowledge_repo/app/utils/time.py
+++ b/knowledge_repo/app/utils/time.py
@@ -1,0 +1,24 @@
+import datetime
+
+
+def time_since(dt, human_readable=False):
+    if dt is None:
+        return None
+    assert isinstance(dt, datetime.datetime)
+    delta = (datetime.datetime.utcnow() - dt).total_seconds()
+    if human_readable:
+        return human_readable_time_delta(delta)
+    return delta
+
+
+def human_readable_time_delta(seconds):
+    if seconds is None:
+        return "Never"
+    elif seconds < 60:
+        return "{:d} seconds ago".format(int(round(seconds)))
+    elif seconds < 60 * 60:
+        return "{:d} minutes ago".format(int(round(seconds / 60)))
+    elif seconds < 24 * 60 * 60:
+        return "{:d} hours ago".format(int(round(seconds / 60 / 60)))
+    else:
+        return "{:d} days ago".format(int(round(seconds / 60 / 60 / 24)))

--- a/knowledge_repo/repositories/dbrepository.py
+++ b/knowledge_repo/repositories/dbrepository.py
@@ -64,7 +64,7 @@ class DbKnowledgeRepository(KnowledgeRepository):
 
     @property
     def revision(self):
-        return self.session.query(func.max(self.PostRef.created_at)).first()[0]
+        return str(self.session.query(func.max(self.PostRef.created_at)).first()[0])
 
     def update(self):
         pass


### PR DESCRIPTION
In v0.7.1 there are some issues regarding checking the revision of DBKnowledgeRepository instances. Rather than force KnowledgeRepository instances to return string revisions, we now simply require them to return something that can be automatically converted to a string, and that is lexically ordered so that newer revisions sort lower than older ones.

There's also some small improvements to the base template to use glyphicons and to show the latest time an update check was performed (on hovering over the last time the index was updated).

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj

