### PR TITLE
Add support for specifying a thumbnail image, and fix some bugs in the post caching mechanism.

### DIFF
--- a/knowledge_repo/postprocessors/format_checks.py
+++ b/knowledge_repo/postprocessors/format_checks.py
@@ -14,14 +14,12 @@ OPTIONAL_FIELD_TYPES = {
     'path': str,
     'updated_at': datetime.datetime,
     'private': bool,   # If true, this post starts out private
-    'allowed_groups': list
+    'allowed_groups': list,
+    'thumbnail': (int, str)
 }
 
 
 class FormatChecks(KnowledgePostProcessor):
-    '''
-    Use this to bootstrap your own KnowledgePostProcessor.
-    '''
     _registry_keys = ['format_checks']
 
     @classmethod


### PR DESCRIPTION
This addresses #51 and the issues in the discussion of #115.

Thumbnails can be specified as integers (in which case the nth image is chosen as the thumbnail) or strings (in which case the string is treated as a url). The resulting url is then hard coded as the thumbnail header of the generated markdown file, which means that if this logic changes in the future, old posts will not be affected.

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj

