### PR TITLE
Small cleanups to indexing, along with some extra debugging tools.

### DIFF
--- a/knowledge_repo/app/app.py
+++ b/knowledge_repo/app/app.py
@@ -12,7 +12,7 @@ from alembic.migration import MigrationContext
 
 import knowledge_repo
 from .proxies import db_session, current_repo
-from .index import update_index, time_since_index, time_since_index_check
+from .index import update_index, time_since_index, time_since_index_check, _update_index
 from .models import db as sqlalchemy_db, Post, User, Tag
 from . import routes
 
@@ -87,6 +87,9 @@ class KnowledgeFlask(Flask):
         self.register_blueprint(routes.stats.blueprint)
         self.register_blueprint(routes.web_editor.blueprint)
         self.register_blueprint(routes.groups.blueprint)
+
+        if self.config['DEBUG']:
+            self.register_blueprint(routes.debug.blueprint)
 
         # Register error handler
         @self.errorhandler(500)
@@ -192,6 +195,10 @@ class KnowledgeFlask(Flask):
     def db_migrate(self, message, autogenerate=True):
         with self.app_context():
             command.revision(self._alembic_config, message=message, autogenerate=autogenerate)
+
+    def db_update_index(self, reindex=True):
+        with self.app_context():
+            _update_index(current_app, force=True, reindex=reindex)
 
     @property
     def supports_threads(self):

--- a/knowledge_repo/app/index.py
+++ b/knowledge_repo/app/index.py
@@ -15,27 +15,46 @@ logger = logging.getLogger(__name__)
 
 
 def is_indexing():
-    return int(IndexMetadata.get('lock', 'index', '0'))
+    timeout = current_app.config.get("INDEXING_TIMEOUT", 10 * 60)  # Default index timeout to 10 minutes (after which indexing will be permitted to run again)
+    last_update = time_since_index()
+    return bool(int(IndexMetadata.get('lock', 'index', '0'))) and last_update is not None and (last_update < timeout)
 
 
 def time_since_index(human_readable=False):
     last_update = IndexMetadata.get_last_update('lock', 'index')
-    return time_since(last_update, human_readable=human_readable)
+    ts = time_since(last_update, human_readable=human_readable)
+    if human_readable:
+        if is_indexing():
+            return 'Currently indexing'
+        if ts is None:
+            return "Never"
+    return ts
 
 
 def time_since_index_check(human_readable=False):
     last_update = IndexMetadata.get_last_update('check', 'index')
+    if human_readable and last_update is None:
+        return "Never"
     return time_since(last_update, human_readable=human_readable)
+
+
+def get_indexed_revisions():
+    indexed = {}
+    for uri in current_repo.uris.values():
+        indexed_revision = IndexMetadata.get('repository_revision', uri)
+        indexed[uri] = indexed_revision
+    return indexed
 
 
 def update_index_required():
     if not current_app.config.get('REPOSITORY_INDEXING_ENABLED', True):
         return False
 
+    interval = current_app.config.get("INDEXING_INTERVAL", 5 * 60)  # Default to 6 minutes between indexing tasks
     seconds = time_since_index()
     seconds_check = time_since_index_check()
 
-    if is_indexing() or (seconds is not None and seconds_check is not None) and (seconds < 5 * 60 or seconds_check < 5 * 60):
+    if is_indexing() or (seconds is not None and seconds_check is not None) and (seconds < interval or seconds_check < interval):
         return False
     try:
         for uri, revision in current_repo.revisions.items():
@@ -67,14 +86,14 @@ def update_index():
         _update_index(current_app)
 
 
-def _update_index(app):
+def _update_index(app, force=False, reindex=False):
 
     context = None
     if not has_app_context():
         context = app.app_context()
         context.__enter__()
 
-    if is_indexing():
+    if not force and is_indexing():
         return
     IndexMetadata.set('lock', 'index', True)
     db_session.commit()
@@ -97,17 +116,13 @@ def _update_index(app):
             post.status = current_repo.PostStatus.UNPUBLISHED
             continue
 
-        # TODO(nikki_ray): This is to support the backfilling of this column. Remove this.
-        if not post.keywords:
-            post.keywords = get_keywords(post)
-
         # Update database according to current state of existing knowledge post and
         # remove from kp_dir. This means that when this loop finishes, kr_dir will
         # only contain posts which are new to the repo.
         kp = kr_dir.pop(post.path)
 
         # Update metadata of post if required
-        if (kp.revision > post.revision or not post.is_published or kp.uuid != post.uuid):
+        if reindex or (kp.revision > post.revision or not post.is_published or kp.uuid != post.uuid):
             if kp.is_valid():
                 logger.info('Recording update to post at: {}'.format(kp.path))
                 post.update_metadata_from_kp(kp)

--- a/knowledge_repo/app/routes/__init__.py
+++ b/knowledge_repo/app/routes/__init__.py
@@ -7,3 +7,4 @@ from . import tags
 from . import vote
 from . import web_editor
 from . import groups
+from . import debug

--- a/knowledge_repo/app/routes/debug.py
+++ b/knowledge_repo/app/routes/debug.py
@@ -1,0 +1,65 @@
+import sys
+import platform
+import types
+import logging
+import tabulate
+import knowledge_repo
+
+from flask import request, current_app, Blueprint
+from ..proxies import current_repo
+from ..index import get_indexed_revisions, is_indexing
+
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+blueprint = Blueprint('debug', __name__,
+                      template_folder='../templates', static_folder='../static')
+
+
+@blueprint.route('/debug/versions', methods=['GET'])
+def show_versions():
+    version_keys = ['__version__', 'VERSION', 'version', '__VERSION__']
+
+    def get_version(module):
+        for key in version_keys:
+            if hasattr(module, key):
+                version = getattr(module, key)
+                if isinstance(version, types.ModuleType):
+                    version = get_version(version)
+                return version
+
+        return 'Unknown'
+
+    versions = []
+    for module_name in sorted(set(name.split('.')[0] for name in sys.modules.keys())):
+        if module_name.startswith('_'):
+            continue
+        module = __import__(module_name)
+        if not hasattr(module, '__file__') or 'site-packages' not in module.__file__:
+            continue
+        versions.append([module_name, get_version(__import__(module_name))])
+
+    # Show revision for mountpoint. Don't show actual uri because database passwords will be leaked
+    revisions = []
+    repo_revisions = current_repo.revisions
+    indexed_revisions = get_indexed_revisions()
+    for mountpoint, uri in current_repo.uris.items():
+        revisions.append([mountpoint or '&lt;root&gt;', repo_revisions[uri], indexed_revisions.get(uri, 'None')])
+
+    return ("Knowledge Repo Version: {}<br/>\n".format(knowledge_repo.__version__) +
+            "Python Version: {}<br/>\n".format(sys.version) +
+            "Platform: {}<br/>\n".format(platform.version()) +
+            "<h2>Repository Revisions</h2>" +
+            ("<i>Currently indexing</i><br />\n" if is_indexing() else "") +
+            tabulate.tabulate(revisions, tablefmt='html') +
+            "<h2>Loaded Packages</h2>\n" +
+            tabulate.tabulate(versions, tablefmt='html', headers=('Mount Point', 'Revision', 'Indexed Revision')))
+
+
+@blueprint.route('/debug/force_reindex', methods=['GET'])
+def force_reindex():
+    reindex = bool(request.args.get('reindex', ''))
+    current_app.db_update_index(reindex=reindex)
+    return "Index Updated"

--- a/resources/extract_images_to_s3.py
+++ b/resources/extract_images_to_s3.py
@@ -24,7 +24,7 @@ class ExtractImagesToS3(ExtractImages):
         # Copy image data to new file
         if is_ref:
             _, tmp_path = tempfile.mkstemp()
-            with open(tmp_path, 'w') as f:
+            with open(tmp_path, 'wb') as f:
                 f.write(kp._read_ref(img_path))
         else:
             tmp_path = img_path

--- a/scripts/knowledge_repo
+++ b/scripts/knowledge_repo
@@ -107,9 +107,7 @@ if (isinstance(args.repo, str) and not args.dev
         and os.path.exists(os.path.join(args.repo, '.resources', 'scripts', 'knowledge_repo'))
         and os.path.abspath(args.repo) != os.path.abspath(os.path.join(os.path.dirname(__file__), '../../'))):
     cmdline_args = ['--noupdate'] + [arg.replace(' ', '\ ') if ' ' in arg else arg for arg in sys.argv[1:]]
-    proc = subprocess.call('{} {}'.format(os.path.join(os.path.abspath(args.repo), '.resources/scripts/knowledge_repo'), ' '.join(cmdline_args)), shell=True)
-    return_code = proc.wait()
-    sys.exit(return_code)
+    sys.exit(subprocess.call('{} {}'.format(os.path.join(os.path.abspath(args.repo), '.resources/scripts/knowledge_repo'), ' '.join(cmdline_args)), shell=True))
 
 # ---------------------------------------------------------------------------------------
 # Everything below this line pertains to actual actions to be performed on the repository
@@ -185,6 +183,11 @@ db_upgrade.add_argument('-db', '--dburi', help='The SQLAlchemy database uri.')
 db_upgrade.add_argument('-c', '--config', default=None, help="The config file from which to read server configuration.")
 db_upgrade.add_argument('-m', '--message', help="The message to use for the database revision.")
 db_upgrade.add_argument('--autogenerate', action='store_true', help="Whether alembic should automatically populate the migration script.")
+
+reindex = subparsers.add_parser('reindex', help='Update the index, updating all posts even if they exist in the database already; but will not lose post views and other usage metadata.')
+reindex.set_defaults(action='reindex')
+reindex.add_argument('-db', '--dburi', help='The SQLAlchemy database uri.')
+reindex.add_argument('-c', '--config', default=None, help="The config file from which to read server configuration.")
 
 # Show version and exit
 if args.version:
@@ -305,3 +308,7 @@ elif args.action == 'db_upgrade':
 elif args.action == 'db_migrate':
     app = repo.get_app(debug=args.debug, db_uri=args.dburi)
     app.db_migrate(args.message, autogenerate=args.autogenerate)
+
+elif args.action == 'reindex':
+    app = repo.get_app(db_uri=args.dburi, debug=args.debug, config=args.config)
+    app.db_update_index(reindex=True)


### PR DESCRIPTION
This patch set fixes a few small reindexing bugs, and adds some debug routes to assist in future problems like this one. In particular it addresses the following:
 - If a reindex has taken longer than 10 minutes, new reindexes are now allowed to occur; preventing a failed reindex / crashed server from preventing the index from being up to date.
 - A manual reindex can now be forced using the `reindex` action in the `knowledge_repo` script or (when running in debug mode) the `/debug/force_reindex` route.
 - Fix a small bug when chaining script and wanting to return the nested script's error code.
 - Fix S3 upload sample script for Python 3.
 - Add a debug route `/debug/versions` that shows the versions of both system and installed packages that are pertinent to the knowledge repository (see screenshot below).

![screen shot 2016-11-16 at 1 00 23 pm](https://cloud.githubusercontent.com/assets/124910/20365684/b3ef968a-abfc-11e6-917a-421f1af9e5bb.png)


Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj

…