### PR TITLE
BadLock: Fix index lock check for postgres

### DIFF
--- a/knowledge_repo/app/index.py
+++ b/knowledge_repo/app/index.py
@@ -15,7 +15,11 @@ logger = logging.getLogger(__name__)
 
 
 def is_indexing():
-    return int(IndexMetadata.get('lock', 'index', '0'))
+    has_lock = IndexMetadata.get('lock', 'index', '0')
+    try:
+        return int(has_lock)
+    except ValueError:  # has_lock is a 'false'/'true' string
+        return {'false': False, 'true': True}.get(has_lock)
 
 
 def time_since_index(human_readable=False):


### PR DESCRIPTION
This PR fixes the following error when running `knowledge-repo` with postgres:

```
    return int(IndexMetadata.get('lock', 'index', '0'))
ValueError: invalid literal for int() with base 10: 'false'
```

Test Plan: 
```bash
$ knowledge_repo --repo <repo> runserver --debug --dburi <some_postgres_db>
```

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj