### PR TITLE
excluded tags typo fixes batch tags

### DIFF
--- a/knowledge_repo/app/routes/tags.py
+++ b/knowledge_repo/app/routes/tags.py
@@ -55,7 +55,7 @@ def render_batch_tags():
             db_session.commit()
 
         tags_to_posts[tag.id] = [(post.path, post.title) for post in posts if
-                                 post.is_published and not post.contains_excluded_tags]
+                                 post.is_published and not post.contains_excluded_tag]
         nonzero_tags.append(tag)
         # so that we can use the tag in the jinja template
         db_session.expunge(tag)


### PR DESCRIPTION
Description of changeset: 

This one character fix gets /batch_tags up and running again:

![image](https://cloud.githubusercontent.com/assets/20175104/20805706/c4740d22-b7ac-11e6-99be-06de7054c551.png)


Test Plan: 

ran the route locally

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj

