### PR TITLE
Always use /feed when searching from searchbar

### DIFF
--- a/knowledge_repo/app/templates/base.html
+++ b/knowledge_repo/app/templates/base.html
@@ -149,7 +149,7 @@
               var keycode = (event.keyCode ? event.keyCode : event.which);
               if(keycode == '13'){
                 var path = document.location.pathname;
-                window.location = path + '?filters=' + $('#searchbar').val()
+                window.location = '/feed?filters=' + $('#searchbar').val()
               }
             });
 


### PR DESCRIPTION
Description of changeset: 

This fixes search when searching from viewing a post or in any other endpoint besides /feed. 

Test Plan: 

Searched from a post view

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj

