### PR TITLE
In DbKnowledgeRepository, better handling of parent arg in _kp_dir

### DIFF
--- a/knowledge_repo/repositories/dbrepository.py
+++ b/knowledge_repo/repositories/dbrepository.py
@@ -212,7 +212,7 @@ class DbKnowledgeRepository(KnowledgeRepository):
                             .filter(self.PostRef.revision == revision)).all()
         for (ref,) in refs:
             if ref is not None:
-                yield posix.relpath(ref, parent)
+                yield posixpath.relpath(ref, parent)
 
     def _kp_has_ref(self, path, reference, revision=None):
         revision = revision or self._kp_get_revision(path, enforce_exists=True)

--- a/knowledge_repo/repositories/dbrepository.py
+++ b/knowledge_repo/repositories/dbrepository.py
@@ -1,7 +1,6 @@
 from builtins import object
 
 import logging
-import os
 import posixpath
 
 from sqlalchemy import create_engine
@@ -213,7 +212,7 @@ class DbKnowledgeRepository(KnowledgeRepository):
                             .filter(self.PostRef.revision == revision)).all()
         for (ref,) in refs:
             if ref is not None:
-                yield os.path.relpath(ref, parent)
+                yield posix.relpath(ref, parent)
 
     def _kp_has_ref(self, path, reference, revision=None):
         revision = revision or self._kp_get_revision(path, enforce_exists=True)

--- a/knowledge_repo/repositories/dbrepository.py
+++ b/knowledge_repo/repositories/dbrepository.py
@@ -212,7 +212,7 @@ class DbKnowledgeRepository(KnowledgeRepository):
                             .filter(self.PostRef.revision == revision)).all()
         for (ref,) in refs:
             if ref is not None:
-                yield posixpath.relpath(ref, parent)
+                yield posixpath.relpath(ref, parent or '')
 
     def _kp_has_ref(self, path, reference, revision=None):
         revision = revision or self._kp_get_revision(path, enforce_exists=True)


### PR DESCRIPTION
Description of changeset:
This addresses issue #155, which was causing issues not to show up in knowledge posts when using a database repository.  The change fixes the `_kp_dir` method of `DbKnowledgeRepository` to look for the parent arg in the `ref` column of the database.

Test Plan:
Without this change, images didn't display in my knowledge posts.  With the change, they did.

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj

