### PR TITLE
Add section in documentation for post headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ tldr: This is short description of the content and findings of the post.
 ---
 ```
 
+*See a full description of headers [further below](https://github.com/airbnb/knowledge-repo#post-headers)*
+
 Users add these notebooks/files to the knowledge repository through the `knowledge_repo` tool, as described below; which allows them to be rendered and curated in the knowledge repository's web app.
 
 If your favourite format is missing, we welcome contributions; and are happy to work with you to get it supported. See the "Contributing" section below to see how to add support for more formats.
@@ -257,6 +259,23 @@ In this case, we would run:
 ```
 knowledge_repo --repo knowledge_data_repo submit knowledge_data_repo/projects/test_knowledge.kp
 ```
+
+### Post Headers
+
+Here is a full list of headers used in the YAML section of knowledge posts:
+
+|header         |required |purpose                                                                            |example                                                                                   |
+|:--------------|:--------|:----------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------------|
+|title          |required |String at top of post                                                              |This post proves that 2+2=4                                                               |
+|authors        |required |User entity that wrote the post in organization specified format                   |authors: <br> - kanye_west<br> - beyonce_knowles                                          |
+|tags           |required |Topics, projects, or any other uniting principle across posts                      |tags: <br> - hiphop<br> - yeezy                                                           |
+|created_at     |required |Date when post was written                                                         |created_at: 2016-04-03                                                                    |
+|updated_at     |required |Date when post was last updated                                                    |created_at: 2016-10-10                                                                    |
+|tldr           |required |Summary of post takeaways that will be visible in /feed                            |tldr: I'ma let you finish, but Beyonce had one of the best videos of all time!            |
+|path           |optional |Instead of specifying post path in the CLI, specify with this post header          |path: projects/path/to/post/on/repo                                                       |
+|thumbnail      |optional |Specify which image is shown in /feed                                              |thumbnail: 3 OR thumbnail: http://cdn.pcwallart.com/images/giraffe-tongue-wallpaper-1.jpg |
+|private        |optional |If included, post is only visible to authors and editors set in repo configuration |private: true                                                                             |
+|allowed_groups |optional |If the post is private, specify additional users or groups who can see the post    |allowed_groups: ['jay_z', 'taylor_swift', 'rap_community']                                |
 
 ### Handling Images
 

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Here is a full list of headers used in the YAML section of knowledge posts:
 
 |header         |required |purpose                                                                            |example                                                                                   |
 |:--------------|:--------|:----------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------------|
-|title          |required |String at top of post                                                              |This post proves that 2+2=4                                                               |
+|title          |required |String at top of post                                                              |title: This post proves that 2+2=4                                                               |
 |authors        |required |User entity that wrote the post in organization specified format                   |authors: <br> - kanye_west<br> - beyonce_knowles                                          |
 |tags           |required |Topics, projects, or any other uniting principle across posts                      |tags: <br> - hiphop<br> - yeezy                                                           |
 |created_at     |required |Date when post was written                                                         |created_at: 2016-04-03                                                                    |

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Here is a full list of headers used in the YAML section of knowledge posts:
 |authors        |required |User entity that wrote the post in organization specified format                   |authors: <br> - kanye_west<br> - beyonce_knowles                                          |
 |tags           |required |Topics, projects, or any other uniting principle across posts                      |tags: <br> - hiphop<br> - yeezy                                                           |
 |created_at     |required |Date when post was written                                                         |created_at: 2016-04-03                                                                    |
-|updated_at     |required |Date when post was last updated                                                    |created_at: 2016-10-10                                                                    |
+|updated_at     |optional |Date when post was last updated                                                    |created_at: 2016-10-10                                                                    |
 |tldr           |required |Summary of post takeaways that will be visible in /feed                            |tldr: I'ma let you finish, but Beyonce had one of the best videos of all time!            |
 |path           |optional |Instead of specifying post path in the CLI, specify with this post header          |path: projects/path/to/post/on/repo                                                       |
 |thumbnail      |optional |Specify which image is shown in /feed                                              |thumbnail: 3 OR thumbnail: http://cdn.pcwallart.com/images/giraffe-tongue-wallpaper-1.jpg |


### PR DESCRIPTION
Description of changeset: 

Quick documentation for post headers. The README is getting to a point where we may need a full site for documentation, but let's get this stuff down for now.

PTAL @NiharikaRay @matthewwardrop @danfrankj 

Test Plan: 


Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj

