### PR TITLE
spread post header documentation to other documentation areas

### DIFF
--- a/knowledge_repo/app/templates/about.html
+++ b/knowledge_repo/app/templates/about.html
@@ -141,6 +141,80 @@
         <pre><code>knowledge_repo --repo &lt;repo_path&gt; submit &lt;the path of the knowledge post&gt;</code></pre>
         <p>In this case, we would run:</p>
         <pre><code>knowledge_repo --repo knowledge_data_repo submit knowledge_data_repo/projects/test_knowledge.kp</code></pre>
+        <h3 id="post-headers">Post Headers</h3>
+        <p>Here is a full list of headers used in the YAML section of knowledge posts:</p>
+        <table>
+        <thead>
+        <tr>
+        <th align="left">header</th>
+        <th align="left">required</th>
+        <th align="left">purpose</th>
+        <th align="left">example</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+        <td align="left">title</td>
+        <td align="left">required</td>
+        <td align="left">String at top of post</td>
+        <td align="left">title: This post proves that 2+2=4</td>
+        </tr>
+        <tr>
+        <td align="left">authors</td>
+        <td align="left">required</td>
+        <td align="left">User entity that wrote the post in organization specified format</td>
+        <td align="left">authors: <br> - kanye_west<br> - beyonce_knowles</td>
+        </tr>
+        <tr>
+        <td align="left">tags</td>
+        <td align="left">required</td>
+        <td align="left">Topics, projects, or any other uniting principle across posts</td>
+        <td align="left">tags: <br> - hiphop<br> - yeezy</td>
+        </tr>
+        <tr>
+        <td align="left">created_at</td>
+        <td align="left">required</td>
+        <td align="left">Date when post was written</td>
+        <td align="left">created_at: 2016-04-03</td>
+        </tr>
+        <tr>
+        <td align="left">updated_at</td>
+        <td align="left">optional</td>
+        <td align="left">Date when post was last updated</td>
+        <td align="left">created_at: 2016-10-10</td>
+        </tr>
+        <tr>
+        <td align="left">tldr</td>
+        <td align="left">required</td>
+        <td align="left">Summary of post takeaways that will be visible in /feed</td>
+        <td align="left">tldr: I&rsquo;ma let you finish, but Beyonce had one of the best videos of all time!</td>
+        </tr>
+        <tr>
+        <td align="left">path</td>
+        <td align="left">optional</td>
+        <td align="left">Instead of specifying post path in the CLI, specify with this post header</td>
+        <td align="left">path: projects/path/to/post/on/repo</td>
+        </tr>
+        <tr>
+        <td align="left">thumbnail</td>
+        <td align="left">optional</td>
+        <td align="left">Specify which image is shown in /feed</td>
+        <td align="left">thumbnail: 3 OR thumbnail: http://cdn.pcwallart.com/images/giraffe-tongue-wallpaper-1.jpg</td>
+        </tr>
+        <tr>
+        <td align="left">private</td>
+        <td align="left">optional</td>
+        <td align="left">If included, post is only visible to authors and editors set in repo configuration</td>
+        <td align="left">private: true</td>
+        </tr>
+        <tr>
+        <td align="left">allowed_groups</td>
+        <td align="left">optional</td>
+        <td align="left">If the post is private, specify additional users or groups who can see the post</td>
+        <td align="left">allowed_groups: [&lsquo;jay_z&rsquo;, &lsquo;taylor_swift&rsquo;, &lsquo;rap_community&rsquo;]</td>
+        </tr>
+        </tbody>
+        </table>
         <h3><a id="Handling_Images_223"></a>Handling Images</h3>
         <p>The knowledge repo’s default behavior is to add the markdown’s contents as is to your knowledge post git repository. If you do not have git LFS set up, it may be in your interest to have these images hosted on some type of cloud storage, so that pulling the repo locally isn’t cumbersome.</p>
         <p>To add support for pushing images to cloud storage, we provide a <a href="https://github.com/airbnb/knowledge-repo/blob/master/resources/extract_images_to_s3.py">postprocessor</a>. This file needs one line to be configured for your organization’s cloud storage. Once configured, the postprocessor’s registry key can be added to the knowledge git repository’s configuration file as a postprocessor.</p>
@@ -241,4 +315,3 @@ $.each(all_headers, function(index, value){
 })
 </script>
 {% endblock %}
-

--- a/knowledge_repo/templates/repo_data_readme.md
+++ b/knowledge_repo/templates/repo_data_readme.md
@@ -27,6 +27,8 @@ tldr: This is short description of the content and findings of the post.
 ---
 ```
 
+See the full list of post header options below.
+
 Users add these notebooks/files to the knowledge repository through the `knowledge_repo` tool, as described below; which allows them to be rendered and curated in the knowledge repository's web app.
 
 If your favourite format is missing, we welcome contributions; and are happy to work with you to get it supported. See the "Contributing" section below to see how to add support for more formats.
@@ -93,6 +95,23 @@ Note that the folder ends in '.kp'. This is added automatically to indicate that
 To update an existing knowledge post, simply pass the `--update` option during the add step, which will allow the add operation to override existing knowledge posts. e.g.
 
 `knowledge_repo --repo <repo_path> add --update <supported knowledge format> <location in knowledge repo>`
+
+### Post Headers
+
+Here is a full list of headers used in the YAML section of knowledge posts:
+
+|header         |required |purpose                                                                            |example                                                                                   |
+|:--------------|:--------|:----------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------------|
+|title          |required |String at top of post                                                              |title: This post proves that 2+2=4                                                               |
+|authors        |required |User entity that wrote the post in organization specified format                   |authors: <br> - kanye_west<br> - beyonce_knowles                                          |
+|tags           |required |Topics, projects, or any other uniting principle across posts                      |tags: <br> - hiphop<br> - yeezy                                                           |
+|created_at     |required |Date when post was written                                                         |created_at: 2016-04-03                                                                    |
+|updated_at     |optional |Date when post was last updated                                                    |created_at: 2016-10-10                                                                    |
+|tldr           |required |Summary of post takeaways that will be visible in /feed                            |tldr: I'ma let you finish, but Beyonce had one of the best videos of all time!            |
+|path           |optional |Instead of specifying post path in the CLI, specify with this post header          |path: projects/path/to/post/on/repo                                                       |
+|thumbnail      |optional |Specify which image is shown in /feed                                              |thumbnail: 3 OR thumbnail: http://cdn.pcwallart.com/images/giraffe-tongue-wallpaper-1.jpg |
+|private        |optional |If included, post is only visible to authors and editors set in repo configuration |private: true                                                                             |
+|allowed_groups |optional |If the post is private, specify additional users or groups who can see the post    |allowed_groups: ['jay_z', 'taylor_swift', 'rap_community']                                |
 
 ### Handling Images
 


### PR DESCRIPTION
Description of changeset: 

Unfortunately right now we have three different places for documentation:

 - repo's README
 - readme stub that's copied to data repos
 - about.html

This PR does the change from https://github.com/airbnb/knowledge-repo/pull/173 into the latter two sources. 

Test Plan: 


Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj

