### PR TITLE
Fix jupyer_client.manager being missing due to upstream changes in nbconvert (explicitly depend on required functionality).

### DIFF
--- a/knowledge_repo/_version.py
+++ b/knowledge_repo/_version.py
@@ -40,7 +40,7 @@ __optional_dependencies__ = {
     # ipynb notebook conversion suport
     'ipynb': [
         'nbformat',
-        'nbconvert',
+        'nbconvert[execute]',
         'traitlets'
     ],
 


### PR DESCRIPTION
This fixes the travis build and client installs.

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
