### PR TITLE
Fix the DBKnowledgeRepository MySQL timeout errors

### DIFF
--- a/knowledge_repo/repositories/dbrepository.py
+++ b/knowledge_repo/repositories/dbrepository.py
@@ -45,7 +45,7 @@ class DbKnowledgeRepository(KnowledgeRepository):
                               Column('status', Integer, default=self.PostStatus.DRAFT.value),
                               Column('ref', String(512)),
                               Column('data', LargeBinary))
-        self.engine = create_engine(engine_uri)
+        self.engine = create_engine(engine_uri, pool_recycle=3600)
         self.session = scoped_session(sessionmaker(bind=self.engine))
         if auto_create:
             postref_table.create(self.engine, checkfirst=True)


### PR DESCRIPTION
Currently MySQL times out after about 8 hours (by default), but the DBKnowledgeRepository does not know this and attempts to connect to the db; resulting in a crash. This patch should cause MySQL connections to be recycled every hour or so; preventing this from happening again.

Description of changeset: 

Test Plan: 


Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
