### PR TITLE
[KR] Add easy link to webeditor

### DIFF
--- a/knowledge_repo/app/routes/render.py
+++ b/knowledge_repo/app/routes/render.py
@@ -100,6 +100,11 @@ def render():
 
     is_author = user_id in [author.id for author in post.authors]
 
+    web_editor_prefixes = current_app.config['WEB_EDITOR_PREFIXES']
+    is_webpost = False
+    if web_editor_prefixes:
+        is_webpost = any(prefix for prefix in web_editor_prefixes if path.startswith(prefix))
+
     rendered = render_template(tmpl,
                                html=html,
                                post_id=post.id,
@@ -115,7 +120,8 @@ def render():
                                total_likes=post.vote_count,
                                tags_list=tags_list,
                                user_subscriptions=user_subscriptions,
-                               webeditor_buttons=False,
+                               show_webeditor_button=is_webpost and is_author,
+                               webeditor_buttons=is_webpost,
                                web_uri=post.kp.web_uri,
                                table_id=None,
                                is_private=(post.private == 1),

--- a/knowledge_repo/app/templates/markdown-base.html
+++ b/knowledge_repo/app/templates/markdown-base.html
@@ -15,6 +15,11 @@
             <button type="button" class="btn btn-default btn-raw">
               View Raw Markdown
             </button>
+            {% if is_author and show_webeditor_button %}
+            <button type="button" class="btn btn-default btn-webeditor">
+              View post in webeditor
+            </button>
+            {% endif %}
           </div>
         </div>
         <div class="col-md-2">
@@ -88,6 +93,10 @@ $("document").ready(function(){
 
   $(".btn-raw").on("click", function(){
     document.location.href = "/raw?markdown=" + encodeURI(post_path);
+  })
+
+  $(".btn-webeditor").on("click", function(){
+    document.location.href = "/posteditor?path=" + encodeURI(post_path);
   })
 });
 


### PR DESCRIPTION
Description of changeset: If you're the author of the webpost, you now get a button on top of the rendered post to quickly take you to the webeditor
![screen shot 2017-01-11 at 4 18 48 pm](https://cloud.githubusercontent.com/assets/4268311/21871916/1f5414b6-d81a-11e6-846e-19e502ddca7a.png)


Test Plan: 
1. Create a webpost where you're the author, publish it, and ensure you see the button (and the button can be clicked to take you to the webpost)
2. Create a webpost where you're not the author, and ensure the button doesn't show up. 

Auto-reviewers:  @matthewwardrop @earthmancash @danfrankj
