### PR TITLE
fix double writing of metadata

### DIFF
--- a/knowledge_repo/post.py
+++ b/knowledge_repo/post.py
@@ -287,7 +287,7 @@ class KnowledgePost(object):
 
     @headers.setter
     def headers(self, headers):
-        self.write(self.read(), headers=headers)
+        self.write(self.read(headers=False), headers=headers)
 
     def update_headers(self, **headers):
         h = self.headers


### PR DESCRIPTION
headers are being written twice since the regex looks for a newline. It seemed safer to take out the headers before writing when updating headers so that we don't have to rely on the regex
