### PR TITLE
Testing verbosity improvements

### DIFF
--- a/knowledge_repo/app/migrations/alembic.ini
+++ b/knowledge_repo/app/migrations/alembic.ini
@@ -30,7 +30,7 @@ handlers =
 qualname = sqlalchemy.engine
 
 [logger_alembic]
-level = INFO
+level = WARN
 handlers =
 qualname = alembic
 

--- a/knowledge_repo/app/models.py
+++ b/knowledge_repo/app/models.py
@@ -242,6 +242,8 @@ class User(db.Model):
                  .filter(Vote.user_id == self.id)
                  .all())
         post_ids = [vote.object_id for vote in votes]
+        if len(post_ids) == 0:
+            return []
         excluded_tags = current_app.config.get('EXCLUDED_TAGS', [])
         posts = (db.session.query(Post)
                  .filter(Post.id.in_(post_ids))

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -45,4 +45,4 @@ echo
 echo "Running regression test suite"
 echo "-----------------------------"
 echo
-nosetests --with-coverage --cover-package=knowledge_repo --verbosity=3 -a '!notest'
+nosetests --with-coverage --cover-package=knowledge_repo --verbosity=1 -a '!notest'


### PR DESCRIPTION
This patch makes three small improvements:
 - Sets Alembic logging to WARN, rather than INFO. This makes the testing output a lot cleaner, and we do not lose any useful information in the process.
 - Sets nosetests verbosity to 1 (the default). The names of tests are not generically useful unless something goes wrong (where it is then displayed in detail).
 - Added a small fix to pre-empt a null result in the favourited posts query for a given user (and hence suppress an SQLAlchemy warning).

Running the tests is now much less verbose, and it is more obvious when something actually goes wrong. You can verify this using:

```
./run_tests.sh
```

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
