### PR TITLE
pass in urlparams to the webeditor form so that users can create their own templates via urlshorteners

### DIFF
--- a/knowledge_repo/app/routes/web_editor.py
+++ b/knowledge_repo/app/routes/web_editor.py
@@ -79,14 +79,16 @@ def post_editor():
     # set defaults
     data = {'title': None,
             'status': current_repo.PostStatus.DRAFT.value,
-            'markdown': None,
+            'markdown': request.args.get('markdown'),
             'thumbnail': '',
             'can_approve': 0,
             'username': g.user.username,
             'created_at': datetime.now(),
             'updated_at': datetime.now(),
             'authors': [g.user.username],
-            'comments': []}
+            'comments': [],
+            'tldr': request.args.get('tldr'),
+            }
 
     if path is not None and path in current_repo:
         kp = current_repo.post(path)


### PR DESCRIPTION
Quick Templating solution for webeditor created posts 

By passing in urlparams, we can create templates for users. Obviously, this feature will need to be used in conjunction with an external url shortener.

http://0.0.0.0:7777/posteditor?markdown=%23%20%28GitHub-Flavored%29%20Markdown%20Editor%0A%0ABasic%20useful%20feature%20list%3A%0A%0A%20%2A%20Ctrl%2BS%20/%20Cmd%2BS%20to%20save%20the%20file%0A%20%2A%20Ctrl%2BShift%2BS%20/%20Cmd%2BShift%2BS%20to%20choose%20to%20save%20as%20Markdown%20or%20HTML%0A%20%2A%20Drag%20and%20drop%20a%20file%20into%20here%20to%20load%20it%0A%20%2A%20File%20contents%20are%20saved%20in%20the%20URL%20so%20you%20can%20share%20files%0A%0A%0AI%27m%20no%20good%20at%20writing%20sample%20/%20filler%20text%2C%20so%20go%20write%20something%20yourself.%0A%0ALook%2C%20a%20list%21%0A%0A%20%2A%20foo%0A%20%2A%20bar%0A%20%2A%20baz%0A%0AAnd%20here%27s%20some%20code%21%20%3A%2B1%3A%0A%0A%60%60%60javascript%0A%24%28function%28%29%7B%0A%20%20%24%28%27div%27%29.html%28%27I%20am%20a%20div.%27%29%3B%0A%7D%29%3B%0A%60%60%60%0A

![image](https://cloud.githubusercontent.com/assets/616139/22035716/dffa07ea-dca5-11e6-9dfb-94e6251910af.png)
