### PR TITLE
Update urls for the online editor.

### DIFF
--- a/knowledge_repo/app/app.py
+++ b/knowledge_repo/app/app.py
@@ -85,7 +85,7 @@ class KnowledgeFlask(Flask):
         self.register_blueprint(routes.vote.blueprint)
         self.register_blueprint(routes.comment.blueprint)
         self.register_blueprint(routes.stats.blueprint)
-        self.register_blueprint(routes.web_editor.blueprint)
+        self.register_blueprint(routes.editor.blueprint)
         self.register_blueprint(routes.groups.blueprint)
 
         if self.config['DEBUG']:

--- a/knowledge_repo/app/routes/__init__.py
+++ b/knowledge_repo/app/routes/__init__.py
@@ -5,6 +5,6 @@ from . import posts
 from . import stats
 from . import tags
 from . import vote
-from . import web_editor
+from . import editor
 from . import groups
 from . import debug

--- a/knowledge_repo/app/routes/index.py
+++ b/knowledge_repo/app/routes/index.py
@@ -12,7 +12,7 @@ import json
 from flask import request, render_template, redirect, Blueprint, current_app, make_response
 from sqlalchemy import case, desc
 
-from ..app import db_session
+from ..proxies import db_session, current_repo
 from ..utils.posts import get_posts
 from ..models import Post, Tag, User, PageView
 from ..utils.requests import from_request_get_feed_params
@@ -229,3 +229,23 @@ def ajax_post_typeahead():
                            'keywords': str(post.keywords)}
         matches += [typeahead_entry]
     return json.dumps(matches)
+
+
+@blueprint.route('/ajax/index/typeahead_tags')
+@blueprint.route('/ajax_tags_typeahead', methods=['GET'])
+def generate_tags_typeahead():
+    return json.dumps([t[0] for t in db_session.query(Tag.name).all()])
+
+
+@blueprint.route('/ajax/index/typeahead_users')
+@blueprint.route('/ajax_users_typeahead', methods=['GET'])
+def generate_users_typeahead():
+    return json.dumps([u[0] for u in db_session.query(User.username).all()])
+
+
+@blueprint.route('/ajax/index/typeahead_paths')
+@blueprint.route('/ajax_paths_typeahead', methods=['GET'])
+def generate_projects_typeahead():
+    # return path stubs for all repositories
+    stubs = ['/'.join(p.split('/')[:-1]) for p in current_repo.dir()]
+    return json.dumps(list(set(stubs)))

--- a/knowledge_repo/app/static/js/tooltips.js
+++ b/knowledge_repo/app/static/js/tooltips.js
@@ -22,7 +22,7 @@ function initializeTooltips(is_webeditor, post_id, id, data_repo_github_root){
 
     if (edit_tooltip[0] !== null){
         edit_tooltip.click(function(){
-          document.location.href =  "/posteditor?post_id=" + id;
+          document.location.href =  "/edit/" + id;
         });
     }
 

--- a/knowledge_repo/app/templates/create-knowledge.html
+++ b/knowledge_repo/app/templates/create-knowledge.html
@@ -14,7 +14,7 @@
     <a class="btn btn-primary" href="create/Rmd" role="button"> R-Markdown </a>
     <a class="btn btn-primary" href="create/md" role="button"> Markdown </a>
     {% if web_editor_enabled %}
-    <a class="btn btn-primary" href="posteditor" role="button"> Web Editor </a>
+    <a class="btn btn-primary" href="{{ url_for('editor.editor') }}" role="button"> Web Editor </a>
     {% endif %}
 </div>
 </center>

--- a/knowledge_repo/app/templates/markdown-base.html
+++ b/knowledge_repo/app/templates/markdown-base.html
@@ -96,7 +96,7 @@ $("document").ready(function(){
   })
 
   $(".btn-webeditor").on("click", function(){
-    document.location.href = "/posteditor?path=" + encodeURI(post_path);
+    document.location.href = "/edit/" + encodeURI(post_path);
   })
 });
 

--- a/knowledge_repo/app/templates/post_editor_base.html
+++ b/knowledge_repo/app/templates/post_editor_base.html
@@ -362,17 +362,17 @@ $("#submission_close").on("click", function(){
     dataType: "json",
     data: JSON.stringify(data),
     contentType: 'application/json',
-    url: '/submit?path={{ path }}',
+    url: '/ajax/editor/submit?path={{ path }}',
     async: true,
     success:function(response_data){
       alert("The status has been changed!")
-      window.location = '/posteditor?path={{ path }}'
+      window.location = '{{ url_for('editor.editor', path=path) }}'
     },
     error: function(response_data){
       console.log("ERROR")
       console.log(JSON.stringify(response_data))
       if (response_data['status'] == 200){
-        window.location = '/posteditor?path={{ path }}'
+        window.location = '{{ url_for('editor.editor', path=path) }}'
       } else {
         alert("Your post wasn't submitted for review, please try again!")
       }
@@ -386,10 +386,10 @@ if ( status == 2 || status == 3 ) {
     var publish_button_text = this.textContent.trim();
     var url = '';
     if (publish_button_text == "Unpublish"){
-      url = '/unpublish_post?path={{ path }}';
+      url = '/ajax/editor/unpublish?path={{ path }}';
       alert_text = 'Your post has been unpublished!';
     } else {
-      url = '/publish_post?path={{ path }}';
+      url = '/ajax/editor/publish?path={{ path }}';
       alert_text = "Your post has been published!";
     }
 
@@ -415,11 +415,11 @@ $("#author_can_publish").on("click", function(){
   $.ajax({
     type: "POST",
     contentType: "application/json",
-    url: "/accept_post?path={{ path }}",
+    url: "/ajax/editor/accept?path={{ path }}",
     async: true,
     success: function(response_data){
       alert("The publishing status was changed!");
-      window.location = '/posteditor?path={{ path }}';
+      window.location = '{{ url_for('editor.editor', path=path) }}';
     },
     error: function(response_data){
       alert("The publishing status was NOT changed");
@@ -471,7 +471,7 @@ $("#btn_save").on("click", function(){
       dataType: "json",
       data: JSON.stringify(data),
       contentType: "application/json",
-      url: '/save_post',
+      url: '/ajax/editor/save',
       async: true,
       success: function(response_data) {
         if (response_data['success'] == 0) {
@@ -480,7 +480,7 @@ $("#btn_save").on("click", function(){
         else {
           $("#btn_save")[0].setAttribute("class", "btn btn-large");
           alert("The post was successfully saved!")
-          window.location = '/posteditor?path=' + response_data['path']
+          window.location = '/edit/' + response_data['path']
         }
       },
       error: function(response_data) {
@@ -495,8 +495,8 @@ $("#btn_save").on("click", function(){
 
 function deleteReview(commentId) {
   $.ajax({
-      type: "GET",
-      url: '/delete_review?path={{ path|urlencode }}&comment_id=' + commentId,
+      type: "DELETE",
+      url: '/ajax/editor/review?path={{ path|urlencode }}&comment_id=' + commentId,
       async: false
   });
   location.reload();
@@ -515,7 +515,7 @@ function postReview() {
       dataType: "json",
       data: JSON.stringify(postContent),
       contentType: "application/json",
-      url: '/review?path={{ path|urlencode }}',
+      url: '/ajax/editor/review?path={{ path|urlencode }}',
       async: false
   });
   location.reload();

--- a/knowledge_repo/app/templates/web_posts.html
+++ b/knowledge_repo/app/templates/web_posts.html
@@ -55,20 +55,20 @@
 $('[data-toggle="tooltip"]').tooltip();
 
 $("#new-post").click(function() {
-  document.location.href = "/posteditor";
+  document.location.href = "{{ url_for('editor.editor') }}";
 });
 
 {% for post in posts %}
 
   $("#tooltip-edit-{{ post.id }}").click(function() {
-    document.location.href = "/posteditor?post_id={{ post.id }}";
+    document.location.href = "{{ url_for('editor.editor', path=post.id) }}";
   });
 
   $("#tooltip-delete-{{ post.id }}").click(function() {
     if (confirm("Are you sure you want to delete this post? You won't be able to recover it if you do.")) {
       $.ajax({
         type: "GET",
-        url: '/delete_post?post_id={{ post.id }}',
+        url: '/ajax/editor/delete?post_id={{ post.id }}',
         async: false
       });
     }

--- a/knowledge_repo/app/utils/emails.py
+++ b/knowledge_repo/app/utils/emails.py
@@ -154,7 +154,7 @@ def send_reviewer_request_email(path, reviewer):
     subject = "Someone requested a web post review from you!"
     msg = Message(subject, [reviewer])
     msg.body = render_template("email_templates/reviewer_request_email.txt",
-                               post_url=url_for('web_editor.post_editor', path=path, _external=True))
+                               post_url=url_for('editor.editor', path=path, _external=True))
     current_app.config['mail'].send(msg)
 
 
@@ -171,5 +171,5 @@ def send_review_email(path, comment_text, commenter='Someone'):
                                commenter=commenter,
                                comment_text=comment_text,
                                post_title=headers['title'],
-                               post_url=url_for('web_editor.post_editor', path=path, _external=True))
+                               post_url=url_for('editor.editor', path=path, _external=True))
     current_app.config['mail'].send(msg)

--- a/tests/test_webeditorposts.py
+++ b/tests/test_webeditorposts.py
@@ -82,7 +82,7 @@ class WebEditorPostTest(unittest.TestCase):
         filled out with the correct values
         """
 
-        rv = self.client.get('/posteditor?path={}'.format(self.post_path))
+        rv = self.client.get('/edit/{}'.format(self.post_path))
         assert rv.status == "200 OK"
         data = rv.data.decode('utf-8')
         soup = BeautifulSoup(data, 'html.parser')
@@ -137,7 +137,7 @@ class WebEditorPostTest(unittest.TestCase):
                 'path': self.post_path
             }
 
-            rv = self.client.post("/save_post",
+            rv = self.client.post("/ajax/editor/save",
                                   data=json.dumps(data),
                                   content_type='application/json',
                                   headers={'user_header': 'webeditor_test_user'})
@@ -153,13 +153,13 @@ class WebEditorPostTest(unittest.TestCase):
         And that going back to the form editor changes the button text
         And a review comment area is added
         """
-        rv = self.client.post('/submit?path={}'.format(self.post_path),
+        rv = self.client.post('/ajax/editor/submit?path={}'.format(self.post_path),
                               data=json.dumps({'post_reviewers': 'test_post_reviewers'}),
                               content_type='application/json')
 
         assert rv.status == "200 OK"
 
-        rv = self.client.get('/posteditor?path={}'.format(self.post_path))
+        rv = self.client.get('/edit/{}'.format(self.post_path))
 
         assert rv.status == "200 OK"
 
@@ -178,7 +178,7 @@ class WebEditorPostTest(unittest.TestCase):
         Clicking the author_can_publish checkbox
         should change the relevant field in the db
         """
-        rv = self.client.post("/accept_post?path={}".format(self.post_path))
+        rv = self.client.post("/ajax/editor/accept?path={}".format(self.post_path))
         assert rv.status == "200 OK"
 
         with self.app.app_context():
@@ -199,14 +199,14 @@ class WebEditorPostTest(unittest.TestCase):
         and the button text
         """
         # test that clicking the publish button changes the status
-        rv = self.client.post('/publish_post?path={}'.format(self.post_path))
+        rv = self.client.post('/ajax/editor/publish?path={}'.format(self.post_path))
         assert rv.status == "200 OK"
 
         with self.app.app_context():
             kp = self.repo.post(self.post_path)
             assert kp.is_published is True
 
-            rv = self.client.get('/posteditor?path={}'.format(self.post_path))
+            rv = self.client.get('/edit/{}'.format(self.post_path))
             assert rv.status == "200 OK"
 
             data = rv.data.decode("utf-8")
@@ -216,14 +216,14 @@ class WebEditorPostTest(unittest.TestCase):
             btn_publish = soup.findAll("button", {"id": "btn_publish"})
             assert btn_publish and btn_publish[0].text.strip() == "Unpublish"
 
-            rv = self.client.post('/unpublish_post?path={}'.format(self.post_path))
+            rv = self.client.post('/ajax/editor/unpublish?path={}'.format(self.post_path))
             assert rv.status == "200 OK"
 
             # TODO(Dan) after manually kick of re-index
             # post = db_session.query(Post).get(self.post_id)
             # assert post.status == self.repo.PostStatus.UNPUBLISHED
 
-            rv = self.client.get('/posteditor?path={}'.format(self.post_path))
+            rv = self.client.get('/edit/{}'.format(self.post_path))
             assert rv.status == "200 OK"
 
             data = rv.data.decode("utf-8")
@@ -236,7 +236,7 @@ class WebEditorPostTest(unittest.TestCase):
     @unittest.skip("post deletion not implemented")
     def test07_test_delete_button(self):
         """Test post deletion."""
-        rv = self.client.get('/delete_post?path={}'.format(self.post_id))
+        rv = self.client.get('/ajax/editor/delete?path={}'.format(self.post_id))
         assert rv.status == "200 OK"
 
         with self.app.app_context():


### PR DESCRIPTION
This post updates the urls used by the web editor, which is now moved from `/post_editor?path=<path>` to `/edit/<path>`. Ajax queries are now moved under to the `/ajax/editor` and `/ajax/index` prefixes as appropriate. This patch does not attempt to fix any issues with the editor itself, but simply updates the url schema.

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
