### PR TITLE
support unicode in tldr and add markdown newline extension

### DIFF
--- a/knowledge_repo/app/utils/render.py
+++ b/knowledge_repo/app/utils/render.py
@@ -19,7 +19,8 @@ MARKDOWN_EXTENSTIONS = ['markdown.extensions.extra',
                         'markdown.extensions.sane_lists',
                         'markdown.extensions.smarty',
                         'markdown.extensions.toc(baselevel=1)',
-                        'markdown.extensions.wikilinks']
+                        'markdown.extensions.wikilinks',
+                        'markdown.extensions.nl2br']
 
 
 def render_post_tldr(post):
@@ -31,7 +32,7 @@ def render_post_tldr(post):
 
 def render_post_header(post):
 
-    header_template = """
+    header_template = u"""
     <div class='metadata'>
     <h1>{title}</h1>
     <span class='authors'>{authors}</span>

--- a/knowledge_repo/postprocessors/format_checks.py
+++ b/knowledge_repo/postprocessors/format_checks.py
@@ -1,4 +1,5 @@
 import datetime
+from past.builtins import basestring
 
 from ..postprocessor import KnowledgePostProcessor
 
@@ -6,7 +7,7 @@ REQUIRED_FIELD_TYPES = {
     'title': str,
     'authors': list,
     'created_at': datetime.datetime,
-    'tldr': str,
+    'tldr': basestring,
     'tags': list
 }
 


### PR DESCRIPTION
Allow the TLDR to be unicode and fix formatting the header causing unicode errors. Also add markdown extension allowing github style md. 

@matthewwardrop @NiharikaRay @earthmancash 
