### PR TITLE
[Knowledge][Bugfix] Allow tag subscription from rendered post

### DIFF
--- a/knowledge_repo/app/static/js/tags.js
+++ b/knowledge_repo/app/static/js/tags.js
@@ -96,7 +96,7 @@ function addTagSubscriptionListener(v) {
     }
     $.ajax({
       type: "POST",
-      url: url_request,
+      url: "/" + url_request,
       async: true,
       success: function() {
         // We want to toggle all the buttons for all the relevant tags


### PR DESCRIPTION
Description of changeset: 
A 6 character change. With the complexity of the post javascript, the url that the subscribe button was going to was `post/<post_path>/toggle_tag_subscription`, which was throwing a 405, method not allowed error (since we only GET posts, not POST). This PR ensures that its `/toggle_tag_subscription` that gets the ajax request. 

Test Plan: 
Go to a post and subscribe to a tag from it. 

Auto-reviewers: @matthewwardrop @earthmancash @danfrankj


