### PR TITLE
git ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,5 @@ web/data/repo.json
 *.pyc
 /build
 /dist
+
+.DS_Store


### PR DESCRIPTION
Description of changeset: 
git ignore .DS_Store used in Mac OS filesystems.

Test Plan: 
nothing

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
