### PR TITLE
exclude deploy directory for checking styles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
 # cache: pip
 
 before_script:
-  - "pep8 --exclude knowledge_repo/app/migrations,build --ignore=E501 ."
+  - "pep8 --exclude knowledge_repo/app/migrations,build,deploy --ignore=E501 ."
 script:
   - bash run_tests.sh
 


### PR DESCRIPTION
Description of changeset: 

we now have a `deploy` directory which included templatized `.py` files that violates python syntax when parsed directly. this PR excludes the directory to prevent those files from being style-checked so we could get a green build.

Test Plan: 

tested on travis.

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
