### PR TITLE
exclude kube directory from style checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
 # cache: pip
 
 before_script:
-  - "pep8 --exclude knowledge_repo/app/migrations,build,deploy --ignore=E501 ."
+  - "pep8 --exclude knowledge_repo/app/migrations,build,deploy,kube --ignore=E501 ."
 script:
   - bash run_tests.sh
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -13,7 +13,7 @@ rm -f .coverage &> /dev/null
 set -e
 
 # Run pep8 tests
-pep8 --exclude knowledge_repo/app/migrations,tests/test_repo,build,deploy --ignore=E501 .
+pep8 --exclude knowledge_repo/app/migrations,tests/test_repo,build,deploy,kube --ignore=E501 .
 
 # Create fake repository and add some sample posts.
 # We use a fake repository here to speed things up, and to avoid using git in test environments


### PR DESCRIPTION
we are adding another directory `kube` to the internal repo which requires style checks to be skipped due to templatized python files.

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
