### PR TITLE
Fix KnowledgePost.thumbnail_uri when not header not processed by ExtractImages for whatever reason.

### DIFF
--- a/knowledge_repo/post.py
+++ b/knowledge_repo/post.py
@@ -303,7 +303,7 @@ class KnowledgePost(object):
     def thumbnail_uri(self):
         thumbnail = self.headers.get('thumbnail')
 
-        if not thumbnail:
+        if not thumbnail or not isinstance(thumbnail, str):
             return None
 
         if ':' not in thumbnail:  # if thumbnail points to a local reference


### PR DESCRIPTION
If a knowledge post is not processed by the ExtractImages PostProcessor, or manually edited, the thumbnail uri might not be in a supported format. This patch adds a check to ensure that the thumbnail header is understood before attempting to use it (in particular, that it is a string; and not an integer or other type).

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
