### PR TITLE
[Knowledge] Add date formatting to comments

### DIFF
--- a/knowledge_repo/app/models.py
+++ b/knowledge_repo/app/models.py
@@ -107,6 +107,10 @@ class Comment(db.Model):
     created_at = db.Column(db.DateTime, default=func.now())
     updated_at = db.Column(db.DateTime, default=func.now(), onupdate=func.now())
 
+    @property
+    def format_created_at(self):
+        return datetime.datetime.strftime(self.created_at, "%Y-%m-%d")
+
 
 class PageView(db.Model):
     __tablename__ = 'pageviews'

--- a/knowledge_repo/app/templates/markdown-rendered.html
+++ b/knowledge_repo/app/templates/markdown-rendered.html
@@ -50,7 +50,7 @@
                   <div class="row">
                     <div class="col-md-11">
                       <div class="post_comment">
-                        Posted by <b>{{ item.author }}</b> on {{ item.created_at_fmt }}
+                        Posted by <b>{{ item.author }}</b> on {{ item.format_created_at }}
                       </div>
                     </div>
                     <div class="col-md-1">


### PR DESCRIPTION
Description of changeset: This is related to issue #214, where the date wasn't showing up in the comments. This PR changes that. 

Test Plan: 
Write a comment, note that the date now shows up in the rendered comment box.
![screen shot 2017-02-06 at 1 54 39 pm](https://cloud.githubusercontent.com/assets/4268311/22668055/2ecd6c4e-ec74-11e6-867c-f8f79a35d712.png)


Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
