### PR TITLE
Improve feed rendering.

### DIFF
--- a/knowledge_repo/app/static/css/custom.css
+++ b/knowledge_repo/app/static/css/custom.css
@@ -98,7 +98,7 @@ body {
   color: #565a5c;
   background-color: whitesmoke;
   font-size: 14px;
-  font-family: 'Lato';
+  font-family: 'Lato', sans-serif;
   /*background-color: #F8F8F8;*/
 }
 
@@ -118,28 +118,13 @@ ul {
     margin-bottom: 10px;
 }
 
-h1 {
-  font-size: 44px;
-}
-h2 {
-  margin-top: 0;
-  margin-bottom: 0;
-  color: #484848;
-  font-size: 32px;
-  font-weight: bolder;
-}
-h3 {
-  font-size: 24px;
-}
-h4 {
-  font-size: 18px;
-}
-h5 {
-  font-size: 16px;
-}
-h6 {
-  font-size: 14px;
-}
+h1              { font-size: 2em; margin: .67em 0 }
+h2              { font-size: 1.5em; margin: .75em 0 }
+h3              { font-size: 1.17em; margin: .83em 0 }
+h5              { font-size: .83em; margin: 1.5em 0 }
+h6              { font-size: .75em; margin: 1.67em 0 }
+h1, h2, h3, h4,
+h5, h6          { font-weight: bolder }
 
 img {
     max-width:100%;
@@ -256,29 +241,6 @@ a.label:focus, a.label:hover {
   color: #9CA299;
 }
 
-.feed-author {
-  padding-bottom: 5px;
-}
-
-.feed-date {
-  color: #565a5c;
-  padding-bottom: 10px;
-}
-
-.feed-date, .feed-tldr {
-  color: #565a5c;
-}
-
-.feed-post {
-  border-bottom: 1px solid #F8F8F8;
-}
-
-.feed-post-counts {
-  color: #aaa;
-  margin-right: 3px;
-  margin-left: 15px;
-}
-
 .content-offset {
   margin-left: 50px;
 }
@@ -366,14 +328,6 @@ a.label:focus, a.label:hover {
   margin-bottom: 0.5em;
   font-weight: bold;
 }
-
-h1              { font-size: 2em; margin: .67em 0 }
-h2              { font-size: 1.5em; margin: .75em 0 }
-h3              { font-size: 1.17em; margin: .83em 0 }
-h5              { font-size: .83em; margin: 1.5em 0 }
-h6              { font-size: .75em; margin: 1.67em 0 }
-h1, h2, h3, h4,
-h5, h6          { font-weight: bolder }
 
 #renderedMarkdown h1:nth-of-type(1) {
   margin-top: 1em;

--- a/knowledge_repo/app/static/css/pages/index-feed.css
+++ b/knowledge_repo/app/static/css/pages/index-feed.css
@@ -1,0 +1,115 @@
+/* This file defines the css styles for the index route */
+
+.feed-post {
+    padding: 10px;
+    border-radius: 10px;
+    cursor: pointer;
+    border: 1px solid transparent;
+    transition: background 0.6s, border 0.6s;
+    display: flex;
+    margin-top: 1em;
+    margin-bottom: 1em;
+}
+.feed-post:hover {
+    background: #fff;
+    border: 1px solid #00a699;
+    transition: background 0.4s, border 0.4s;
+}
+.feed-post:active {
+    transform: scale(.99,0.99);
+}
+
+.feed-post .feed-thumbnail {
+    height: 200px;
+    flex-shrink: 0;
+    flex-grow: 0;
+    width: 200px;
+    position: relative;
+    vertical-align: center;
+    background: #fff;
+    border: 1px solid #bbb;
+    border-radius: 5px;
+    box-shadow: 0px 1px 3px rgba(0,0,0,0.2);
+    margin: 0px;
+}
+.feed-post .feed-thumbnail img {
+    position: absolute;
+    top: 0px;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    max-width:150px;
+    max-height: 150px;
+    height:auto;
+    width:auto;
+    margin: auto;
+}
+.feed-post:hover .feed-thumbnail {
+    border: transparent;
+    box-shadow: none;
+    transition: border 0.6s, box-shadow 0.6s;
+}
+
+.feed-post .feed-metadata {
+    position:relative;
+    margin: 0px;
+    margin-left: 1em;
+    width: 100%;
+}
+.feed-post .feed-metadata span {
+    display:  block;
+}
+
+.feed-post .feed-title {
+    margin-top: 0px;
+    font-size: 1.6em;
+    font-weight: bolder;
+}
+
+.feed-post .feed-authors, .feed-post .feed-tags {
+  margin-bottom: .3em;
+}
+
+.feed-post .feed-tldr {
+    height: 5em;
+    padding: 10px;
+    background: rgba(0,0,0,0.03);
+    border-top-left-radius: 5px;
+    border-top-right-radius: 5px;
+    font-style: italic;
+    text-align: justify;
+    overflow: hidden;
+}
+.feed-post .feed-tldr-expander {
+    padding: 3px;
+    display: block;
+    text-align: center;
+    font-size: small;
+    background: rgba(0,0,0,0.03);
+    border-bottom-left-radius: 5px;
+    border-bottom-right-radius: 5px;
+    color: #00a699;
+    margin-bottom: 0.3em;
+    }
+.feed-post .feed-tldr-expander:hover {
+    background: rgba(0,0,0,0.07);
+}
+
+.feed-post .feed-dates {
+    font-style: italic;
+    color: #aaa;
+    font-size: small;
+    margin-top: 3px;
+}
+
+.feed-post .feed-stats {
+    display: inline-block;
+    float: right;
+    margin-top: 3px;
+    text-align:center;
+}
+.feed-post .feed-stats span {
+  display: inline;
+  margin-left: 1em;
+  color: #aaa;
+}

--- a/knowledge_repo/app/static/js/pages/index-feed.js
+++ b/knowledge_repo/app/static/js/pages/index-feed.js
@@ -1,0 +1,32 @@
+(function($) {
+
+    function em_to_px(parent, em) {
+        return parseFloat(getComputedStyle(parent).fontSize) * em;
+    }
+
+    function posts_open(event) {
+        window.location = $(this).data('url');
+    }
+
+    function posts_expand_tldr(event) {
+        event.stopPropagation();
+        var tldr = $(this).parent().children('.feed-tldr');
+
+        if (! tldr.data('expanded') ) {
+            // Compute height of nested (and potentially masked elements) elements
+            var height = $(tldr).children().map(function(undefined, elem) { return $(elem).outerHeight() + 5; }).toArray().reduce(function(prev, curr) { return prev + curr; }, 0);
+
+            $(tldr).animate({"height": Math.max(height + 25, em_to_px(this, 5) + 5)}, 400);
+            $(tldr).data('expanded', true);
+            $(this).html('<a>- Show Less</a>');
+        } else {
+            $(tldr).animate({"height": em_to_px(this, 5) + 5}, 400);
+            $(tldr).data('expanded', false);
+            $(this).html('<a>+ Show More</a>');
+        }
+    }
+
+    $("body").on("click", ".feed-post", posts_open);
+    $("body").on("click", ".feed-post .feed-tldr-expander", posts_expand_tldr);
+
+})(jQuery);

--- a/knowledge_repo/app/templates/index-feed.html
+++ b/knowledge_repo/app/templates/index-feed.html
@@ -1,81 +1,72 @@
 {% extends "index-base.html" %}
 
+{% block style_links %}
+{{ super() }}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/pages/index-feed.css')}}">
+{% endblock %}
+
+{% macro render_tag(tag, post_id) %}
+
+{% set tag_flat = tag.replace("/", "__") %}
+    <a  href="/tag_pages?tag={{ tag|urlencode }}"
+        data-tag-name="{{ tag_flat }}"
+        data-container="body"
+        data-toggle="popover"
+        data-placement="bottom"
+        data-html="true"
+    {% if tag in feed_params['subscriptions'] %}
+        class="label label-tag label-subscribed pop"
+        data-content="<div class='content'>
+            <button class='btn btn-small btn-primary btn-unsubscribe'
+                    id='tag-subscription-{{post_id}}__{{tag_flat}}'>
+                <i class='glyphicon glyphicon-remove-sign glyphicon-white'></i>Unsubscribe
+            </button></div>"
+    {% else %}
+        class="label label-tag label-unsubscribed pop"
+        data-content="<div class='content'>
+            <button class='btn btn-small btn-default btn-subscribe'
+                    id='tag-subscription-{{post_id}}__{{tag_flat}}'>
+                <i class='glyphicon glyphicon-ok-sign glyphicon-filled'></i>Subscribe
+            </button></div>"
+    {% endif %}
+        class="text">
+      {{ "#" + tag }}
+    </a>
+{% endmacro %}
+
 {% block inner_content %}
 
-  <br>
-
-  {% for post in posts %}
-    {% set idx_item = loop.index0 %}
-    {% set stats = post_stats[post.path] %}
-    <div class='row row-space-4 panel feed-post'>
-      <div class='panel-header panel-light'>
-        <div class = "col-md-10">
-          <a href="{{'/post/' + post.path|urlencode }}">
-            {{ post.title |title }}
-          </a>
-        </div>
-        <div class='feed-post-counts'>
-          <i class="glyphicon glyphicon-eye-open"> </i> {{ stats['distinct_views'] }}&nbsp
-          <i class="glyphicon glyphicon-heart-empty"></i> {{ stats['total_likes']}}&nbsp
-          <i class="glyphicon glyphicon-comment"></i> {{ stats['total_comments']}}
-        </div>
-      </div>
-      <div class='panel-body'>
-        <div class="col-md-6">
-          <ul class="post-list" style='list-style-type: none; padding-left: 0px'>
-            <li class="feed-author"> {{ format_authors(post.authors)|safe }}</li>
-            <li class="feed-date"> Updated: {{ post['updated_at'].date().isoformat() }}</li>
-            <li class="feed-tags">
-              {% for tag_obj in post.tags %}
-                {% set tag = tag_obj.name %}
-                {% set tag_flat = tag.replace("/", "__") %}
-                <a  href="/tag_pages?tag={{ tag|urlencode }}"
-                    data-tag-name="{{ tag_flat }}"
-                    data-container="body"
-                    data-toggle="popover"
-                    data-placement="bottom"
-                    data-html="true"
-                    {% if tag in feed_params['subscriptions'] %}
-                      class="label label-tag label-subscribed pop"
-                      data-content="<div class='content'>
-                       <button class='btn btn-small btn-primary btn-unsubscribe'
-                               title=''
-                               id='tag-subscription-{{idx_item}}__{{tag_flat}}'>
-                         <i class='glyphicon glyphicon-remove-sign glyphicon-white'></i>Unsubscribe
-                     </button></div>"
-                    {% else %}
-                      class="label label-tag label-unsubscribed pop"
-                      data-content="<div class='content'>
-                       <button class='btn btn-small btn-default btn-subscribe'
-                             title=''
-                             id='tag-subscription-{{idx_item}}__{{tag_flat}}'>
-                         <i class='glyphicon glyphicon-ok-sign glyphicon-filled'></i>Subscribe
-                       </button></div>"
-                    {% endif %}
-                    class="text">
-                  {{ "#" + tag}}
-                </a>
-              {% endfor %}
-            </li>
-          </ul>
-          <p class="feed-tldr">
-            <i>{{ post['tldr']|safe }}</i>
-            <br>
-            <br>
-            <a href="{{'/post/' + post.path|urlencode }}">Read post</a>
-          </p>
-        </div>
-        <div class="col-md-6">
-          <center><img src="{{ post['thumbnail'] if post['thumbnail'] else '/static/images/default_thumbnail.png' }}" style="max-width:100%;max-height:225px" /></center>
-        </div>
-      </div>
+{% for post in posts %}
+<div class="row feed-post" data-path='{{post.path|urlencode}}' data-url="{{url_for('posts.render', path=post.path)}}">
+    <div class='feed-thumbnail'>
+        <img src="{{ post['thumbnail'] if post['thumbnail'] else '/static/images/default_thumbnail.png' }}" />
     </div>
-  {% endfor %}
+    <div class='feed-metadata'>
+            <span class="feed-title">{{ post.title }}</span>
+            <span class="feed-authors"> {{ format_authors(post.authors)|safe }}</span>
+            <span class="feed-tags">
+                {% for tag_obj in post.tags %}
+                    {{ render_tag(tag_obj.name, loop.index0) }}
+                {% endfor %}
+            </span>
+            <span class='feed-tldr'>{{ post['tldr']|safe }}</span>
+            <span class='feed-tldr-expander'>+ Show More</span>
+            <span class='feed-stats'>
+                {% set stats = post_stats[post.path] %}
+                <span title="Users who Viewed"><i class="glyphicon glyphicon-eye-open"> </i> {{ stats['distinct_views'] }}</span>
+                <span title="Number of Favorites"><i class="glyphicon glyphicon-heart-empty"></i> {{ stats['total_likes']}}</span>
+                <span title="Comments"><i class="glyphicon glyphicon-comment"></i> {{ stats['total_comments']}}</span>
+            </span>
+            <span class="feed-dates">Created on {{ post.created_at.strftime("%B %d, %Y") }} (last updated {{ post.updated_at.strftime("%B %d, %Y") }})</span>
+    </div>
+</div>
+{% endfor %}
 
 {% endblock %}
 
 {% block scripts %}
 {{ super () }}
+<script src="{{ url_for('static', filename='js/pages/index-feed.js') }}"></script>
 <script src="{{ url_for('static', filename='js/helpers.js')}}" type='text/javascript'></script>
 <script src="{{ url_for('static', filename='js/tags.js')}}" type='text/javascript'></script>
 <script type="text/javascript">

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -26,7 +26,7 @@ class FeedTest(unittest.TestCase):
         assert (rv.status == "200 OK")
         data = rv.data.decode('utf-8')
         soup = BeautifulSoup(data, 'html.parser')
-        all_posts = soup.findAll('div', {'class': 'row row-space-4 panel feed-post'})
+        all_posts = soup.findAll('div', {'class': 'row feed-post'})
         self.data = all_posts
 
     def test02_test_link_to_post(self):
@@ -95,13 +95,13 @@ class FeedTest(unittest.TestCase):
         posts = self.data
 
         for post in posts:
-            author = post.findAll('li', {'class': 'feed-author'})
+            author = post.findAll('span', {'class': 'feed-authors'})
             assert author
 
-            date = post.findAll('li', {'class': 'feed-date'})
+            date = post.findAll('span', {'class': 'feed-dates'})
             assert date
 
-            tags = post.findAll('li', {'class': 'feed-tags'})
+            tags = post.findAll('span', {'class': 'feed-tags'})
             assert tags
 
             image = post.findAll('img')
@@ -118,7 +118,7 @@ class FeedTest(unittest.TestCase):
 
         data = rv.data.decode('utf-8')
         soup = BeautifulSoup(data, 'html.parser')
-        all_posts = soup.findAll('div', {'class': 'row row-space-4 panel feed-post'})
+        all_posts = soup.findAll('div', {'class': 'row feed-post'})
         assert not all_posts
 
     def test06_real_filter(self):
@@ -132,7 +132,7 @@ class FeedTest(unittest.TestCase):
 
         data = rv.data.decode('utf-8')
         soup = BeautifulSoup(data, 'html.parser')
-        all_posts = soup.findAll('div', {'class': 'row row-space-4 panel feed-post'})
+        all_posts = soup.findAll('div', {'class': 'row feed-post'})
         assert len(all_posts) == 3, "Expected 3 posts, found {}".format(len(all_posts))
 
 if __name__ == '__main__':


### PR DESCRIPTION
This patch set improves the rendering of the knowledge post index feed by:
 - Making rows more compact and with more consistent heights (descriptions are collapsed)
 - Visual feedback for interaction (backgrounds on hover, depression when clicked)
 - Making the who row clickable to take you to the post proper

The new javascript methods are encapsulated in a closure so that they do not clutter the global namespace, and both the javascript and css files are loaded only on the page they are required.

Below are some screenshots of the new theming:

<img width="1077" alt="screen shot 2017-02-08 at 11 44 19 am" src="https://cloud.githubusercontent.com/assets/124910/22754338/106af4de-edf4-11e6-9e06-f479d8c9e289.png">
<img width="1158" alt="screen shot 2017-02-08 at 12 24 33 pm" src="https://cloud.githubusercontent.com/assets/124910/22755866/e3c76ad8-edf9-11e6-897c-a5f8a0b30d21.png">



Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
