### PR TITLE
Improve the pagination controls.

### DIFF
--- a/knowledge_repo/app/static/css/custom.css
+++ b/knowledge_repo/app/static/css/custom.css
@@ -296,10 +296,6 @@ a.label:focus, a.label:hover {
   opacity: 0.5;
 }
 
-.feed-post-counts, .glyphicon:first-child {
-  margin-left: 0px;
-}
-
 .content {
   border-left: 1px solid #F8F8F8;
   background-color: white;
@@ -507,8 +503,34 @@ span.index-view-name {
   opacity: 1;
 }
 
-.pagination-group > a {
-  border: 0;
+.pagination-bar {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.pagination-stepper.disabled {
+    color: #9CA299;
+    opacity: 0.5;
+    cursor: default;
+}
+
+.pagination {
+margin: 0px;
+}
+.pagination-stepper {
+  padding: 8px;
+  display: block;
+}
+.pagination li a {
+  color: #00a699;
+}
+.pagination .active a {
+background-color: #00a699;
+border-color: #00a699;
+}
+.pagination .active a:hover {
+background-color: #11b6a2;
+border-color: #11b6aa;
 }
 
 .page-btn {
@@ -519,37 +541,11 @@ span.index-view-name {
   background-color: inherit;
 }
 
-.pagination-group > a:hover,
-.pagination-group > a:active,
-.pagination-group > a:focus,
-.pagination-group > a:active:focus,
-.pagination-group > a:active:hover {
-  background-color: inherit;
-  border: 0px;
-  opacity: inherit;
-  outline: none;
-  box-shadow: none;
-  color: inherit;
-}
-
 .page-btn:hover, .page-btn:active {
   background-color: inherit;
   border: 0px;
   opacity: inherit;
   outline: none;
-}
-
-.active-page, .active-page:hover {
-  color: #00a699;
-  padding-bottom: 2px;
-  background-color: inherit;
-  border: 0px;
-  opacity: inherit;
-}
-
-.feed-post-counts > .glyphicon-heart-empty,
-.feed-post-counts > .glyphicon-comment {
-  padding-left: 10px;
 }
 
 .cluster-header {

--- a/knowledge_repo/app/static/css/pages/index-feed.css
+++ b/knowledge_repo/app/static/css/pages/index-feed.css
@@ -1,5 +1,10 @@
 /* This file defines the css styles for the index route */
 
+#feed-posts {
+    margin-top: 2em;
+    margin-bottom: 2em;
+}
+
 .feed-post {
     padding: 10px;
     border-radius: 10px;
@@ -31,6 +36,7 @@
     border-radius: 5px;
     box-shadow: 0px 1px 3px rgba(0,0,0,0.2);
     margin: 0px;
+    transition: border 0.4s, box-shadow 0.4s;
 }
 .feed-post .feed-thumbnail img {
     position: absolute;

--- a/knowledge_repo/app/templates/index-base.html
+++ b/knowledge_repo/app/templates/index-base.html
@@ -11,13 +11,46 @@
   {% endfor %}
 {% endmacro %}
 
+{% macro pagination(max_pages=10, extremes=True, autohide=True) %}
+  {% if feed_params %}
+    {% set start = feed_params['start'] | default(0) %}
+    {% set results = feed_params['results'] | default(10) %}
+    {% set page = 1 if (start == 0) else (start//results + 1) %}
+    {% set page_count = feed_params['page_count'] | default(1) %}
+
+    {% if autohide and page_count > 1 %}
+      {% set page_nums = pagination_pages(current_page=page, page_count=page_count, max_pages=max_pages, extremes=extremes) %}
+
+      <div class='pagination-bar' role="group">
+        <a href="{{ "javascript:;" if (page == 1) else modify_query(start=(page-2)*results) }}" class="pagination-stepper {{ "disabled" if page == 1 }}">
+          <i class="glyphicon glyphicon-chevron-left"></i>
+        </a>
+
+        <ul class="pagination">
+          {% for page_num in page_nums %}
+            {% if loop.index0 > 0 and page_num - page_nums[loop.index0 - 1] > 1 %}
+              <li class="disabled"><a>&middot;&middot;&middot;</a></li>
+            {% endif %}
+            <li {% if page == page_num %}class="active"{% endif %}><a href= "{{ modify_query(start=(page_num-1)*results) }}"> {{ page_num }} </a></li>
+          {% endfor %}
+        </ul>
+
+        {% set href = "#" if (page == 1) else modify_query(start=(page)*results) %}
+        <a href="{{ "javascript:;" if (page == page_count) else modify_query(start=(page)*results) }}" class="pagination-stepper {{ "disabled" if page == page_count }}">
+        <i class="glyphicon glyphicon-chevron-right"></i>
+        </a>
+      </div>
+
+    {% endif %}
+  {% endif %}
+
+{% endmacro %}
 
 {% block title %} Knowledge Repo {% endblock %}
 
 {% block content %}
 
   <div class="row">
-    <br>
     <div class="col-md-5">
       <div class="btn-group btn-group-justified index-view-btn-group" role="group">
         <a href="/feed" class="btn btn-default btn-card no-underline" role="button">
@@ -35,38 +68,11 @@
       </div>
     </div>
 
-  {% if request.endpoint != 'index.render_cluster' %}
-  <div class='col-md-3 col-md-offset-4'>
-    {% set start = feed_params['start'] | default(0) %}
-    {% set results = feed_params['results'] | default(10) %}
-    {% set page = 1 if (start == 0) else (start//results + 1) %}
-
-    <div class="btn-group btn-sm btn-group-justified pagination-group" role="group">
-      {% set href = "#" if (page == 1) else request.path %}
-        <a href="{{ href }}" data-page="{{ page }}"
-           class="btn btn-default {{ "disabled" if (page == 1)}} prev-btn">
-          <i class="glyphicon glyphicon-chevron-left"></i>
-        </a>
-
-      {% if page == 1 %}
-        {% set page_nums = [page, page + 1, page + 2] %}
-      {% else %}
-        {% set page_nums = [page - 1, page, page + 1] %}
-      {% endif %}
-      {% for page_num in page_nums %}
-        {% if page == page_num %}
-          <a href= "{{ request.path }}"  data-page="{{ page_num }}" class="btn btn-default page-btn active-page"> {{ page_num }} </a>
-        {% else %}
-          <a href = "{{ request.path }}"  data-page="{{ page_num }}" class="btn btn-default page-btn"> {{ page_num }} </a>
-        {% endif %}
-      {% endfor %}
-
-      <a href="{{ request.path }}" class="btn btn-default next-btn" data-page="{{ page }}">
-        <i class="glyphicon glyphicon-chevron-right"></i>
-      </a>
+    {% if request.endpoint != 'index.render_cluster' %}
+    <div class='pull-right'>
+      {{ pagination(max_pages=5, extremes=False) }}
     </div>
-  </div>
-  {% endif %}
+    {% endif %}
 
   </div>
 
@@ -74,62 +80,10 @@
     {% block inner_content %}
     {% endblock %}
   </div>
-{% endblock %}
 
-{% block scripts %}
-{{ super() }}
-<script type="text/javascript">
 
-    $( document ).ready(function() {
-      $.ajaxSetup({
-        cache: true
-      });
+{{ pagination(max_pages=10) }}
 
-      function getParameters() {
-        var queries = {};
-        $.each(document.location.search.substr(1).split('&'), function(c,q) {
-        if (q.length > 0) {
-          var i = q.split('=');
-          queries[i[0].toString()] = decodeURIComponent(
-            i[1].toString().replace(/\+/g, '%20')
-          );
-        }
-      });
-      return queries;
-    }
-
-    // format the page navigation buttons - prev, btn, and page numbers
-    parameters = getParameters();
-
-    // By default, show 10 results
-    if (!("results" in parameters)){
-      parameters["results"] = 10;
-    }
-
-    if ($(".prev-btn").data("page") != 1){
-      prev_parameters = $.extend(true, {}, parameters);
-      prev_parameters["start"] = (parseInt(prev_parameters["start"]) - 10).toString();
-      $(".prev-btn").href += "?" + $.param(prev_parameters);
-    }
-
-    $(".page-btn").each(function(){
-      page = $(this).data("page");
-      page_parameters = $.extend(true, {}, parameters);
-      page_parameters["start"] = ((page - 1) * parameters["results"]).toString();
-      $(this)[0].href += "?" + $.param(page_parameters);
-    })
-
-    next_parameters = $.extend(true, {}, parameters);
-    if ("start" in next_parameters){
-      next_parameters["start"] = (parseInt(next_parameters["start"]) + 10).toString();
-    } else {
-      next_parameters["start"] = next_parameters["results"];
-    }
-    if ($(".next-btn").length > 0) {
-      $(".next-btn")[0].href += "?" + $.param(next_parameters);
-    }
-  });
-</script>
 {% endblock %}
 
 

--- a/knowledge_repo/app/templates/index-feed.html
+++ b/knowledge_repo/app/templates/index-feed.html
@@ -36,31 +36,33 @@
 
 {% block inner_content %}
 
-{% for post in posts %}
-<div class="row feed-post" data-path='{{post.path|urlencode}}' data-url="{{url_for('posts.render', path=post.path)}}">
-    <div class='feed-thumbnail'>
-        <img src="{{ post['thumbnail'] if post['thumbnail'] else '/static/images/default_thumbnail.png' }}" />
+<div id="feed-posts">
+    {% for post in posts %}
+    <div class="row feed-post" data-path='{{post.path|urlencode}}' data-url="{{url_for('posts.render', path=post.path)}}">
+        <div class='feed-thumbnail'>
+            <img src="{{ post['thumbnail'] if post['thumbnail'] else '/static/images/default_thumbnail.png' }}" />
+        </div>
+        <div class='feed-metadata'>
+                <span class="feed-title">{{ post.title }}</span>
+                <span class="feed-authors"> {{ format_authors(post.authors)|safe }}</span>
+                <span class="feed-tags">
+                    {% for tag_obj in post.tags %}
+                        {{ render_tag(tag_obj.name, loop.index0) }}
+                    {% endfor %}
+                </span>
+                <span class='feed-tldr'>{{ post['tldr']|safe }}</span>
+                <span class='feed-tldr-expander'>+ Show More</span>
+                <span class='feed-stats'>
+                    {% set stats = post_stats[post.path] %}
+                    <span title="Users who Viewed"><i class="glyphicon glyphicon-eye-open"> </i> {{ stats['distinct_views'] }}</span>
+                    <span title="Number of Favorites"><i class="glyphicon glyphicon-heart-empty"></i> {{ stats['total_likes']}}</span>
+                    <span title="Comments"><i class="glyphicon glyphicon-comment"></i> {{ stats['total_comments']}}</span>
+                </span>
+                <span class="feed-dates">Created on {{ post.created_at.strftime("%B %d, %Y") }} (last updated {{ post.updated_at.strftime("%B %d, %Y") }})</span>
+        </div>
     </div>
-    <div class='feed-metadata'>
-            <span class="feed-title">{{ post.title }}</span>
-            <span class="feed-authors"> {{ format_authors(post.authors)|safe }}</span>
-            <span class="feed-tags">
-                {% for tag_obj in post.tags %}
-                    {{ render_tag(tag_obj.name, loop.index0) }}
-                {% endfor %}
-            </span>
-            <span class='feed-tldr'>{{ post['tldr']|safe }}</span>
-            <span class='feed-tldr-expander'>+ Show More</span>
-            <span class='feed-stats'>
-                {% set stats = post_stats[post.path] %}
-                <span title="Users who Viewed"><i class="glyphicon glyphicon-eye-open"> </i> {{ stats['distinct_views'] }}</span>
-                <span title="Number of Favorites"><i class="glyphicon glyphicon-heart-empty"></i> {{ stats['total_likes']}}</span>
-                <span title="Comments"><i class="glyphicon glyphicon-comment"></i> {{ stats['total_comments']}}</span>
-            </span>
-            <span class="feed-dates">Created on {{ post.created_at.strftime("%B %d, %Y") }} (last updated {{ post.updated_at.strftime("%B %d, %Y") }})</span>
-    </div>
+    {% endfor %}
 </div>
-{% endfor %}
 
 {% endblock %}
 

--- a/knowledge_repo/app/utils/posts.py
+++ b/knowledge_repo/app/utils/posts.py
@@ -4,6 +4,7 @@ Functions include:
     - get_posts
     - get_all_post_stats
 """
+import math
 from flask import current_app
 from sqlalchemy import func, distinct, or_
 
@@ -103,6 +104,8 @@ def get_posts(feed_params):
         posts = [post[0] for post in posts]
 
     # get the right indexes
+    feed_params['posts_count'] = len(posts)
+    feed_params['page_count'] = int(math.ceil(float(len(posts)) / feed_params['results']))
     posts = posts[feed_params['start']:feed_params[
         'start'] + feed_params['results']]
 


### PR DESCRIPTION
Description of changeset: 
This changeset improves the styling of the feed page by adjusting margins along with a new set of pagination controls, along with another pagination bar at the bottom of the page. The pagination controls disappear if there is only one page. The code also removes the need for custom javascript on the page, and fixes a small oversight in the css for the feed hover css (the thumbnail border was not transitioning properly).

<img width="1105" alt="screen shot 2017-02-10 at 10 04 33 pm" src="https://cloud.githubusercontent.com/assets/124910/22851619/ff450236-efdc-11e6-8885-793713df9f94.png">
<img width="1127" alt="screen shot 2017-02-10 at 10 04 45 pm" src="https://cloud.githubusercontent.com/assets/124910/22851620/ff4a83a0-efdc-11e6-9d18-c138be8117d8.png">

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
