### PR TITLE
Fix Windows deployment related code

### DIFF
--- a/knowledge_repo/app/deploy/__init__.py
+++ b/knowledge_repo/app/deploy/__init__.py
@@ -1,4 +1,16 @@
+import logging
+
 from .common import KnowledgeDeployer, get_app_builder
+
+# The following subclasses of KnowledgeDeployer must be imported in order to be registered as a deployer and hence
+# made accessible using `KnowledgeDeployer.using(..)`.
 from .flask import FlaskDeployer
-from .gunicorn import GunicornDeployer
 from .uwsgi import uWSGIDeployer
+
+# Wrap the gunicorn deployer in a try/except block, as it has a hard dependency on gunicorn which does not work on
+# non-POSIX systems, or if it is not installed.
+try:
+    from .gunicorn import GunicornDeployer
+except:
+    logging.warn("Gunicorn deployer is not available. It only works on POSIX platforms (e.g. Linux, Mac OS X, etc). "
+                  "If you are using a POSIX platform, please ensure that `gunicorn` is installed.")

--- a/scripts/knowledge_repo
+++ b/scripts/knowledge_repo
@@ -234,6 +234,7 @@ if args.action == 'create':
         raise ValueError("File already exists at '{}'. Please choose a different filename and try again.".format(args.filename))
     shutil.copy(src, args.filename)
     print("Created a {format} knowledge post template at {filename}.".format(format=args.format, filename=args.filename))
+    sys.exit(0)
 
 # # Check which branches have local work
 if args.action == 'drafts':


### PR DESCRIPTION
This fixes two related issues:
 - The `create` action in the knowledge_repo script did not terminate upon succeeding, allowing subsequent code to run, which included importing of the deployment code. On the the Windows platform, this resulted in an error importing gunicorn (gunicorn does not support non UNIX platforms).
 - A hard import of GunicornDeployer would, on Windows platforms, make it impossible to "deploy" the server. I do not imagine Windows servers being used often in this capacity, but it is worth preventing this spurious behaviour.

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
