### PR TITLE
Fix Rmd conversion in Windows.

### DIFF
--- a/knowledge_repo/converters/rmd.py
+++ b/knowledge_repo/converters/rmd.py
@@ -15,7 +15,8 @@ class RmdConverter(KnowledgePostConverter):
     def from_file(self, filename, rebuild=True):
         Rmd_filename = filename
         if rebuild:
-            _, tmp_path = tempfile.mkstemp()
+            tmp_fd, tmp_path = tempfile.mkstemp()
+            os.close(tmp_fd)
 
             runcmd = """R --vanilla --slave -e "library(knitr); setwd('{0}'); \
                         x = knit('{1}', '{2}', quiet=T)" """.format(os.path.abspath(os.path.dirname(filename)),

--- a/run_tests.bat
+++ b/run_tests.bat
@@ -42,4 +42,4 @@ POPD
 %PYTHON%\\python.exe scripts/knowledge_repo --repo="%test_repo_path%" --dev add knowledge_repo/templates/knowledge_template.md -p projects/test/md_test -m "Test commit" --branch master
 
 REM "Running regression test suite"
-nosetests --with-coverage --cover-package=knowledge_repo --verbosity=1
+%PYTHON%\\python.exe -m nose --with-coverage --cover-package=knowledge_repo --verbosity=1


### PR DESCRIPTION
Fix Rmd conversion in Windows, which is currently failing due to stricter simultaneous write permissions on Windows than POSIX systems.

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
