### PR TITLE
Fix malformated tags_list breaking javascript in post preview mode

### DIFF
--- a/knowledge_repo/app/routes/posts.py
+++ b/knowledge_repo/app/routes/posts.py
@@ -142,7 +142,7 @@ def _render_preview(path, tmpl):
                            unique_views=0,
                            likes=1,
                            total_likes=0,
-                           tags_list=','.join(post.headers.get('tags', [])),
+                           tags_list=post.headers.get('tags', []),
                            user_subscriptions=[],
                            webeditor_buttons=False,
                            table_id=None)


### PR DESCRIPTION
I just realised the javascript wasn't executing properly in preview mode (so the code folding didn't work while previewing). It is due to the var tags_list being rendered as a list but with no brackets '[' and ']' around it; removing the ','.join method casts it as a list instead of a string and fixes it. 

Test Plan: 
1. Run an instance of the knowledge repo
2. Preview any post and verify that no errors were raised in the javacript console

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
