### PR TITLE
Add support for modifier keys when click on post panels

### DIFF
--- a/knowledge_repo/app/static/js/pages/index-feed.js
+++ b/knowledge_repo/app/static/js/pages/index-feed.js
@@ -5,7 +5,13 @@
     }
 
     function posts_open(event) {
-        window.location = $(this).data('url');
+        var is_mac = navigator.platform.indexOf('Mac') != -1;
+        if (is_mac && event.metaKey || !is_mac && event.ctrlKey) {
+            window.open($(this).data('url'), '_blank');
+        } else {
+            window.location = $(this).data('url');
+        }
+
     }
 
     function posts_expand_tldr(event) {


### PR DESCRIPTION
Unfortunately, since the HTML5 specification prohibits nested anchor tags, we cannot have the panel be a link it self without using javascript (unless we forgo the ability to click on authors/etc). To work around this, I add in this PR support for detecting the appropriate modifier keys and opening in a new tab accordingly.

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
