### PR TITLE
Fix plotly, tags and 'Hide All Code' button for markdown

### DIFF
--- a/knowledge_repo/app/static/js/pages/index-feed.js
+++ b/knowledge_repo/app/static/js/pages/index-feed.js
@@ -5,7 +5,13 @@
     }
 
     function posts_open(event) {
-        window.location = $(this).data('url');
+        var is_mac = navigator.platform.indexOf('Mac') != -1;
+        if (is_mac && event.metaKey || !is_mac && event.ctrlKey) {
+            window.open($(this).data('url'), '_blank');
+        } else {
+            window.location = $(this).data('url');
+        }
+
     }
 
     function posts_expand_tldr(event) {

--- a/knowledge_repo/app/templates/base.html
+++ b/knowledge_repo/app/templates/base.html
@@ -17,7 +17,7 @@
         <script src="{{ url_for('static', filename='modules/select2/js/select2.min.js')}}"></script>
         <script src="{{ url_for('static', filename='modules/hightlight.pack.js/highlight.pack.js')}}"></script>
         <script src="{{ url_for('static', filename='modules/marked.js/marked.js')}}"></script>
-        <!-- <script src="{{ url_for('static', filename='modules/plotly-latest.js/plotly-latest.js')}}"></script> -->
+        <script src="{{ url_for('static', filename='modules/plotly-latest.js/plotly-latest.js')}}"></script>
 
         <!-- require js is used for plotly, but has a bunch of collisions with other js packages
              make sure to have it be last js package imported -->

--- a/knowledge_repo/app/templates/base.html
+++ b/knowledge_repo/app/templates/base.html
@@ -17,6 +17,7 @@
         <script src="{{ url_for('static', filename='modules/select2/js/select2.min.js')}}"></script>
         <script src="{{ url_for('static', filename='modules/hightlight.pack.js/highlight.pack.js')}}"></script>
         <script src="{{ url_for('static', filename='modules/marked.js/marked.js')}}"></script>
+        <script src="{{ url_for('static', filename='modules/plotly-latest.js/plotly-latest.js')}}"></script>
 
         <!-- require js is used for plotly, but has a bunch of collisions with other js packages
              make sure to have it be last js package imported -->

--- a/knowledge_repo/app/templates/base.html
+++ b/knowledge_repo/app/templates/base.html
@@ -17,7 +17,7 @@
         <script src="{{ url_for('static', filename='modules/select2/js/select2.min.js')}}"></script>
         <script src="{{ url_for('static', filename='modules/hightlight.pack.js/highlight.pack.js')}}"></script>
         <script src="{{ url_for('static', filename='modules/marked.js/marked.js')}}"></script>
-        <script src="{{ url_for('static', filename='modules/plotly-latest.js/plotly-latest.js')}}"></script>
+        <!-- <script src="{{ url_for('static', filename='modules/plotly-latest.js/plotly-latest.js')}}"></script> -->
 
         <!-- require js is used for plotly, but has a bunch of collisions with other js packages
              make sure to have it be last js package imported -->


### PR DESCRIPTION
Description of changeset: 
Change jquery selectors for renderedMarkdown (was changed from id to class), so that tags and 'Hide All Code' button work again
Add plotly.js as static module and place it before required.js to fix plotly charts in markdown

Test Plan: 


Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
