### PR TITLE
Improvements to the Knowledge Repo UI

### DIFF
--- a/knowledge_repo/app/app.py
+++ b/knowledge_repo/app/app.py
@@ -140,6 +140,13 @@ class KnowledgeFlask(Flask):
             return response
 
         @self.context_processor
+        def login_information():
+            return {
+                'username': g.user.username,
+                'name': g.user.format_name
+            }
+
+        @self.context_processor
         def webediting_enabled():
             # TODO: Link this more to KnowledgeRepository capability and
             # configuration rather than a specific name.

--- a/knowledge_repo/app/app.py
+++ b/knowledge_repo/app/app.py
@@ -141,10 +141,13 @@ class KnowledgeFlask(Flask):
 
         @self.context_processor
         def login_information():
-            return {
-                'username': g.user.username,
-                'name': g.user.format_name
-            }
+            if hasattr(g, 'user'):
+                return {
+                    'username': g.user.username,
+                    'name': g.user.format_name
+                }
+            else:
+                return {}
 
         @self.context_processor
         def webediting_enabled():

--- a/knowledge_repo/app/routes/posts.py
+++ b/knowledge_repo/app/routes/posts.py
@@ -1,5 +1,6 @@
 import logging
-from flask import request, url_for, redirect, render_template, current_app, Blueprint, g
+import os
+from flask import request, url_for, redirect, render_template, current_app, Blueprint, g, Response
 
 from ..proxies import db_session, current_repo
 from ..models import User, Post, PageView
@@ -19,7 +20,15 @@ blueprint = Blueprint('posts', __name__,
 def render(path):
     """ Render the knowledge post with all the related formatting """
 
+    action = request.args.get('action', 'render')
     mode = request.args.get('render', 'html')
+
+    if action == 'download':
+        post = current_repo.post(path)
+        return Response(
+            post.to_string(format='kp'),
+            mimetype="application/zip",
+            headers={"Content-disposition": "attachment; filename={}".format(os.path.basename(post.path))})
 
     username, user_id = g.user.username, g.user.id
 

--- a/knowledge_repo/app/routes/posts.py
+++ b/knowledge_repo/app/routes/posts.py
@@ -184,11 +184,8 @@ def about():
 def download():
     "Downloads resources associated with a post."
 
-    path = request.args.get('post')
-    post = current_repo.post(path)
-
+    post = current_repo.post(request.args.get('post'))  # Note: `post` is expected to be a post path
     resource_type = request.args.get('type', 'source')
-    post = current_repo.post(path)
 
     if resource_type in ('kp', 'zip'):
         filename = os.path.basename(post.path)

--- a/knowledge_repo/app/routes/posts.py
+++ b/knowledge_repo/app/routes/posts.py
@@ -18,8 +18,10 @@ blueprint = Blueprint('posts', __name__,
 @blueprint.route('/post/<path:path>', methods=['GET'])
 @PageView.logged
 def render(path):
-    """ Render the knowledge post with all the related formatting """
-    
+    """
+    Render the knowledge post with all the related formatting.
+    """
+
     mode = request.args.get('render', 'html')
     username, user_id = g.user.username, g.user.id
 
@@ -60,7 +62,7 @@ def render(path):
         if user_id not in allowed_users:
             return render_template("permission_ask.html", authors=post.authors_string)
 
-    rendered = render_post(post)
+    rendered = render_post(post, with_toc=True)
     raw_post = render_post_raw(post) if mode == 'raw' else None
 
     comments = post.comments
@@ -139,7 +141,7 @@ def _render_preview(path, tmpl):
     if not post:
         raise Exception("unable to find post at {}".format(path))
 
-    rendered = render_post(post)
+    rendered = render_post(post, with_toc=True)
     raw_post = render_post_raw(post) if (mode == 'raw') else None
 
     return render_template(tmpl,
@@ -175,6 +177,7 @@ def render_legacy():
 def about():
     """Renders about page. This is the html version of REAMDE.md"""
     return render_template("about.html")
+
 
 @blueprint.route('/ajax/post/download', methods=['GET'])
 @PageView.logged

--- a/knowledge_repo/app/static/css/pages/base.css
+++ b/knowledge_repo/app/static/css/pages/base.css
@@ -36,14 +36,6 @@ color: #fff;
     color: #fff;
     border: none;
     transition: background 0.2s;
-    /*border-radius: 5px;
-    box-shadow: none;
-    border: none;
-    padding: 20px;
-    padding-top: 22px;
-    margin: 0px;
-    display: block;
-    border-bottom: 3px solid transparent;*/
 }
 #navbar .navbar-form .input-group #searchbar:focus {
     background: #aaa;

--- a/knowledge_repo/app/static/css/pages/base.css
+++ b/knowledge_repo/app/static/css/pages/base.css
@@ -1,3 +1,129 @@
+.navbar {
+    background-color: #565a5c;
+    border-color: #565a5c;
+    color: #fff;
+    box-shadow: 0px 1px 5px rgba(0,0,0,0.5);
+    z-index: 10000;
+}
+.navbar-inverse .navbar-nav>li>a {
+color: #fff;
+}
+.navbar .navbar-brand {
+color: #fff;
+}
+@media (min-width: 768px) {
+    #navbar {
+        display: flex!important;
+    }
+}
+#navbar .navbar-form {
+    flex-grow: 1;
+    display: flex;
+}
+#navbar .navbar-form .input-group {
+    flex-grow: 1;
+    display: flex;
+}
+#navbar .navbar-form .input-group .twitter-typeahead {
+    flex-grow: 1;
+    flex-shrink: 1;
+    width: auto;
+    display: flex!important;
+}
+#navbar .navbar-form .input-group #searchbar {
+    width: 100%;
+    background: #999;
+    color: #fff;
+    border: none;
+    transition: background 0.2s;
+    /*border-radius: 5px;
+    box-shadow: none;
+    border: none;
+    padding: 20px;
+    padding-top: 22px;
+    margin: 0px;
+    display: block;
+    border-bottom: 3px solid transparent;*/
+}
+#navbar .navbar-form .input-group #searchbar:focus {
+    background: #aaa;
+    box-shadow: none;
+    transition: background 0.3s;
+}
+#navbar .navbar-form .btn-default {
+    border-color: whitesmoke;
+}
+#navbar .navbar-form .input-group #searchbar::-webkit-input-placeholder { /* Chrome */
+  color: #fff;
+  opacity: 0.5;
+  font-style: italic;
+}
+#navbar .navbar-form .input-group #searchbar:-ms-input-placeholder { /* IE 10+ */
+  color: #fff;
+  opacity: 0.5;
+  font-style: italic;
+}
+#navbar .navbar-form .input-group #searchbar::-moz-placeholder { /* Firefox 19+ */
+  color: #fff;
+  opacity: 0.5;
+  font-style: italic;
+}
+#navbar .navbar-form .input-group #searchbar:-moz-placeholder { /* Firefox 4 - 18 */
+  color: #fff;
+  opacity: 0.5;
+  font-style: italic;
+}
+.navbar a:hover {
+    background: #06c6b6;
+    opacity: 1;
+    border-color: #06c6b6;
+}
+.page-container {
+    margin-top: 70px;
+}
+
+#navbar .searchbar .input-group-btn {
+    width: auto;
+}
+#navbar .navbar-form {
+    box-shadow: none;
+    border: none;
+}
+#navbar ul li.dropdown-header {
+    padding-left: 15px;
+}
+
+#navbar .navbar-button {
+    align-self: center;
+}
+
+#navbar .btn-default:hover,
+#navbar .btn-default:focus,
+#navbar .btn-default:active {
+    opacity: 1;
+}
+
+.spinner {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    margin-left: -50px; /* half width of the spinner gif */
+    margin-top: -50px; /* half height of the spinner gif */
+    text-align:center;
+    z-index:1234;
+    overflow: auto;
+    width: 100px; /* width of the spinner gif */
+    height: 102px; /*hight of the spinner gif +2px to fix IE8 issue */
+}
+
+.table {
+  font-size: 14px;
+}
+
+.modal-content {
+  max-width: 1024px;
+}
+
 .twitter-typeahead {
   width: 100%;
 }
@@ -30,7 +156,75 @@
     margin-right: auto;
     padding-left: 25px;
     padding-right: 25px;
-    width: 1045px;
+    /*width: 1045px;*/
+}
+
+/* Panels */
+
+.side-panel {
+    position: fixed;
+    overflow-y: auto;
+    max-height: calc(100% - 50px);
+    color: #aaa;
+    padding-bottom: 2em;
+    margin-top: -20px;
+}
+
+.side-panel::-webkit-scrollbar {
+    display: none;
+}
+
+.side-panel .section {
+    border-bottom: 1px solid #aaa;
+    display: block;
+    padding-top: 10px;
+    padding-bottom: 5px;
+    font-variant: small-caps;
+    margin-top: 1em;
+    margin-bottom: 0.5em;
+}
+
+.side-panel .section:first-of-type {
+    margin-top: 6px;
+}
+
+.side-panel .subsection {
+    display: block;
+    font-variant: small-caps;
+    margin-top: 0.7em;
+}
+
+.side-panel ul {
+    margin: 0px;
+    padding-left: 0px;
+    list-style-type: disc;
+}
+
+.side-panel ul li {
+    margin-left: 1.5em;
+}
+
+.side-panel ul.nav > li {
+    margin-left: 0px;
+}
+
+.side-panel a {
+    display: block;
+    padding: 3px;
+    color: #aaa;
+    border-radius: 3px;
+    transition: color 0.2s;
+}
+.side-panel a:hover {
+    color: #00a699;
+    transition: color 0.3s;
+}
+.side-panel a.highlight {
+    font-weight: bold;
+}
+
+.side-panel a:link:hover {
+    opacity: 1;
 }
 
 /* navbar elements*/
@@ -42,12 +236,6 @@
 
 .navbar-text[href]:hover {
   color: white;
-}
-
-#searchbar {
-  border: 1px solid #ccc;
-  margin-top:10px;
-  width: 250px;
 }
 
 /* footer elements */
@@ -557,4 +745,35 @@ border-color: #11b6aa;
   outline: none;
   box-shadow: none;
   -webkit-box-shadow: none;
+}
+
+#panel-main .nav-tabs {
+    border-color: #aaa;
+    margin-top: 0px;
+}
+
+#panel-main .nav-tabs>li>a {
+    color: #9CA299;
+}
+
+#panel-main .nav-tabs>li.active>a,
+#panel-main .nav-tabs>li.active>a:focus,
+#panel-main .nav-tabs>li.active>a:hover {
+    border-color: #aaa;
+    border-bottom-color: transparent;
+    color: #000;
+}
+
+#panel-main .nav-tabs>li>a:hover,
+#panel-main .nav>li>a:focus {
+    background-color: #fff;
+    opacity: 1;
+    border-bottom-color: #aaa;
+}
+
+:target:before {
+  content:"";
+  display:block;
+  height:70px; /* fixed header height*/
+  margin:-70px 0 0; /* negative fixed header height */
 }

--- a/knowledge_repo/app/static/css/pages/index-feed.css
+++ b/knowledge_repo/app/static/css/pages/index-feed.css
@@ -119,3 +119,32 @@
   margin-left: 1em;
   color: #aaa;
 }
+
+@media (max-width: 650px) {
+    .feed-post {
+        flex-direction: column;
+        border-radius: 0px;
+        margin-left: -25px;
+        margin-right: -25px;
+        margin-bottom: 10px;
+        border-bottom: 1px solid #ddd;
+    }
+
+    .feed-post .feed-thumbnail {
+        align-self: center;
+        margin-bottom: 1em;
+        width: 150px;
+        height: 150px;
+    }
+
+    .feed-post .feed-thumbnail img {
+        align-self: center;
+        margin-bottom: 1em;
+        max-width: 125px;
+        max-height: 125px;
+    }
+
+    .feed-post .feed-metadata {
+        margin-left: 0px;
+    }
+}

--- a/knowledge_repo/app/static/css/pages/markdown-base.css
+++ b/knowledge_repo/app/static/css/pages/markdown-base.css
@@ -1,13 +1,22 @@
 .renderedMarkdown {
-    border: 1px solid #bbb;
+    border: 1px solid #aaa;
     border-radius: 3px;
     padding: 1.5em;
     background: #fff;
     color: #484848;
-    margin-top: 2em;
     margin-bottom: 2em;
     position: relative;
     box-shadow: 0px 2px 3px rgba(0,0,0,0.1);
+}
+
+@media (max-width: 992px) {
+    .renderedMarkdown {
+        border-radius: 0px;
+        border-left: none;
+        border-right: none;
+        margin-left: -25px;
+        margin-right: -25px;
+    }
 }
 
 .renderedMarkdown h1,
@@ -81,7 +90,74 @@
     max-width: 80%;
 }
 
+.renderedMarkdown .table-wrapper {
+    overflow-x: auto;
+    display: block;
+}
+
 .renderedMarkdown table {
+    margin-left: auto;
+    margin-right: auto;
+    margin-top: 1em;
+    margin-bottom: 1em;
+    border-collapse: collapse;
+    border-spacing: 0;
+    color: #000;
+    table-layout: fixed;
+    border: 1px solid #aaa;
+    padding: 2px;
+    border-collapse: separate;
+}
+.renderedMarkdown thead th {
+    border-left: 1px solid #ddd;
+    border-bottom: 1px solid #ddd;
+}
+.renderedMarkdown thead th:first-child {
+    border-left: none;
+}
+.renderedMarkdown thead > tr:last-child > th {
+    border-bottom: 1px solid #aaa;
+    vertical-align: bottom;
+}
+.renderedMarkdown tr, th, td {
+    text-align: center;
+    vertical-align: middle;
+    padding: 0.5em 0.5em;
+    line-height: normal;
+    white-space: normal;
+    max-width: none;
+    border: none;
+}
+.renderedMarkdown th {
+    font-weight: bold;
+    text-align: right;
+}
+.renderedMarkdown thead th {
+    text-align: center;
+}
+.renderedMarkdown tr th {
+    background: rgba(255,255,255,0.5);
+}
+.renderedMarkdown tr > td:first-child:empty {
+    background: #fff;
+}
+.renderedMarkdown tr > td:first-child:empty + th {
+    border-left: 1px solid #aaa;
+}
+.renderedMarkdown tr > th + td {
+    border-left: 1px solid #aaa;
+}
+.renderedMarkdown tr > td + th {
+    border-left: 1px solid #000;
+}
+.renderedMarkdown tbody tr:nth-child(odd) {
+    background: #f5f5f5;
+}
+.renderedMarkdown tbody tr:hover {
+    background: rgba(66, 165, 245, 0.2);
+}
+
+/*.renderedMarkdown table {
   margin: 10px auto;
   display: block;
   overflow-x: auto;
@@ -104,7 +180,7 @@
 .renderedMarkdown table th, .renderedMarkdown table td {
   border: 1px solid grey;
   padding: 0.5em;
-}
+}*/
 
 .renderedMarkdown .codehilite {
   margin-top: 25px;
@@ -150,6 +226,9 @@
 .codetoggleall {
   width: 140px;
   border-top-right-radius: 0px;
+  border-radius: 3px;
+  top: -35px;
+  z-index: 3;
 }
 
 .codetoggle:hover, .codetoggleall:hover {
@@ -162,6 +241,12 @@
 
 .codetoggle:active, .codetoggleall:active {
   background: #edd114;
+}
+
+@media (max-width: 992px) {
+    .codetoggle, .codetoggleall {
+        display:none;
+    }
 }
 
 .renderedMarkdown ul > li > p {
@@ -199,4 +284,38 @@
 
 .renderedMarkdown .codehilite:hover .codetoggle {
     opacity: 1;
+}
+
+.side-panel .btn-download {
+    background: #ccc;
+    color: #fff;
+    border: none;
+    transition: background-color 0.3s;
+    margin: 5px;
+    overflow: hidden;
+}
+
+.side-panel .btn-download:hover {
+    background: #00a699;
+    color: #fff;
+    opacity: 1;
+    transition: background-color 0.2s;
+}
+
+.side-panel .toc ul.nav {
+    list-style-type: decimal;
+}
+
+.side-panel .toc ul.nav > li {
+    display: list-item;
+    margin-left: 1.5em;
+    font-weight: normal;
+}
+
+.side-panel .toc ul.nav > li > a {
+    padding: 3px;
+}
+
+.side-panel .toc ul.nav > li.active {
+    font-weight: bold;
 }

--- a/knowledge_repo/app/static/css/pages/markdown-base.css
+++ b/knowledge_repo/app/static/css/pages/markdown-base.css
@@ -157,31 +157,6 @@
     background: rgba(66, 165, 245, 0.2);
 }
 
-/*.renderedMarkdown table {
-  margin: 10px auto;
-  display: block;
-  overflow-x: auto;
-  border-spacing: 10px;
-  border: transparent;
-}
-
-.renderedMarkdown table tr th {
-    background: #d8d8d8;
-}
-
-.renderedMarkdown table tr:nth-child(2n) th {
-    background: #e8e8e8;
-}
-
-.renderedMarkdown table tr:nth-child(2n+1) td {
-    background: #f8f8f8;
-}
-
-.renderedMarkdown table th, .renderedMarkdown table td {
-  border: 1px solid grey;
-  padding: 0.5em;
-}*/
-
 .renderedMarkdown .codehilite {
   margin-top: 25px;
   margin-bottom: 25px;

--- a/knowledge_repo/app/static/js/pages/base.js
+++ b/knowledge_repo/app/static/js/pages/base.js
@@ -1,0 +1,64 @@
+$(document).ready(function() {
+    $("#searchbar")[0].setSelectionRange(1000, 1000);
+
+    $('#searchbar').typeahead({
+        hint: false,
+        highlight: true,
+        minLength: 1
+    }, {
+        name: 'knowledge_posts',
+        limit: 20,
+        display: function(item) {
+            return item.title + " - " + item.author;
+        },
+        templates: {
+            empty: Handlebars.compile(
+                '<div class="tt-not-found">' +
+                'Unable to find any posts that match the current query' +
+                '</div>'
+            ),
+            suggestion: function(data) {
+                return '<p style="overflow-wrap:break-word">' + data.title + ' – <em>' + data.author + '</em></p>';
+            }
+        },
+        source: function(q, sync, async) {
+            $.ajax('/ajax/index/typeahead?search=' + q, {
+                success: function(data, status) {
+                    async(JSON.parse(data));
+                }
+            })
+        }
+    });
+
+
+    $('#searchbar').bind('typeahead:select', function(obj, datum, name) {
+        window.location = '/post/' + encodeURIComponent(datum.path);
+    });
+
+    $('#searchbar').keypress(function(event) {
+        var keycode = (event.keyCode ? event.keyCode : event.which);
+        if (keycode == '13') {
+            var path = document.location.pathname;
+            window.location = '/feed?filters=' + $('#searchbar').val()
+        }
+    });
+
+    var padding = $('.tt-menu').outerWidth()
+    $('.tt-menu').width($('#searchbar').width() + padding + "px")
+
+
+    function update_panel_widths(panel_name) {
+        if (window.matchMedia( "(min-width: 1200px)" ).matches){
+            $(panel_name).width($(panel_name).parent().width());
+            $(panel_name).css("position", "fixed");
+        } else {
+            $(panel_name).width('auto');
+            $(panel_name).css("position", "relative");
+        }
+    }
+
+    update_panel_widths('#panel-left');
+    update_panel_widths('#panel-right');
+    $(window).resize(update_panel_widths.bind(null, '#panel-left'));
+    $(window).resize(update_panel_widths.bind(null, '#panel-right'));
+});

--- a/knowledge_repo/app/templates/base.html
+++ b/knowledge_repo/app/templates/base.html
@@ -1,164 +1,145 @@
 <!DOCTYPE html>
 <html>
 
-    <head>
-        <meta charset="utf-8">
+  <head>
+    <meta charset="utf-8">
 
-        <title>{% block title %}{% endblock %}</title>
+    <title>{% block title %}Knowledge Repo{% endblock %}</title>
 
-        <!-- js includes at the top as post embedded js colliding -->
-        <script src="{{ url_for('static', filename='modules/jquery/jquery.min.js')}}"></script>
-        <script src="{{ url_for('static', filename='modules/tether/js/tether.min.js')}}"></script>
-        <script src="{{ url_for('static', filename='modules/bootstrap/js/bootstrap.min.js')}}"></script>
-        <script src="{{ url_for('static', filename='modules/bootstrap-slider/js/bootstrap-slider.min.js')}}"></script>
-        <script src="{{ url_for('static', filename='modules/typeahead.js/typeahead.bundle.min.js')}}"></script>
-        <script src="{{ url_for('static', filename='modules/handlebars/js/handlebars.js')}}"></script>
-        <script src="{{ url_for('static', filename='js/helpers.js')}}"></script>
-        <script src="{{ url_for('static', filename='modules/select2/js/select2.min.js')}}"></script>
-        <script src="{{ url_for('static', filename='modules/hightlight.pack.js/highlight.pack.js')}}"></script>
-        <script src="{{ url_for('static', filename='modules/marked.js/marked.js')}}"></script>
+    <!-- js includes at the top as post embedded js colliding -->
+    <script src="{{ url_for('static', filename='modules/jquery/jquery.min.js')}}"></script>
+    <script src="{{ url_for('static', filename='modules/tether/js/tether.min.js')}}"></script>
+    <script src="{{ url_for('static', filename='modules/bootstrap/js/bootstrap.min.js')}}"></script>
+    <script src="{{ url_for('static', filename='modules/bootstrap-slider/js/bootstrap-slider.min.js')}}"></script>
+    <script src="{{ url_for('static', filename='modules/typeahead.js/typeahead.bundle.min.js')}}"></script>
+    <script src="{{ url_for('static', filename='modules/handlebars/js/handlebars.js')}}"></script>
+    <script src="{{ url_for('static', filename='js/helpers.js')}}"></script>
+    <script src="{{ url_for('static', filename='modules/select2/js/select2.min.js')}}"></script>
+    <script src="{{ url_for('static', filename='modules/hightlight.pack.js/highlight.pack.js')}}"></script>
+    <script src="{{ url_for('static', filename='modules/marked.js/marked.js')}}"></script>
 
-        <!-- require js is used for plotly, but has a bunch of collisions with other js packages
+    <!-- require js is used for plotly, but has a bunch of collisions with other js packages
              make sure to have it be last js package imported -->
-        <script src="{{ url_for('static', filename='modules/require.js/require.min.js')}}"></script>
+    <script src="{{ url_for('static', filename='modules/require.js/require.min.js')}}"></script>
+    <script src="{{ url_for('static', filename='js/pages/base.js')}}"></script>
 
-        <!--[if lt IE 9]>
+    <!--[if lt IE 9]>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.6.2/html5shiv.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/es5-shim/2.1.0/es5-shim.min.js"></script>
         <![endif]-->
-        <link rel="stylesheet" href="{{ url_for('static', filename='modules/bootstrap/css/bootstrap.min.css')}}">
-        <link rel="stylesheet" href="{{ url_for('static', filename='modules/bootstrap-slider/css/bootstrap-slider.min.css')}}">
-        <link rel="stylesheet" type='text/css' href="{{ url_for('static', filename='css/custom.css') }}">
-        <link rel="stylesheet" type='text/css' href="{{ url_for('static', filename='modules/select2/css/select2.min.css') }}">
-        <link href='https://fonts.googleapis.com/css?family=Lato:400,900|Playfair+Display|Source+Serif+Pro:400,700' rel='stylesheet' type='text/css'>
-        <link rel="shortcut icon" href="{{ url_for('static', filename='images/favicon.png') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='modules/bootstrap/css/bootstrap.min.css')}}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='modules/bootstrap-slider/css/bootstrap-slider.min.css')}}">
+    <link rel="stylesheet" type='text/css' href="{{ url_for('static', filename='css/pages/base.css') }}">
+    <link rel="stylesheet" type='text/css' href="{{ url_for('static', filename='modules/select2/css/select2.min.css') }}">
+    <link href='https://fonts.googleapis.com/css?family=Lato:400,900|Playfair+Display|Source+Serif+Pro:400,700' rel='stylesheet' type='text/css'>
+    <link rel="shortcut icon" href="{{ url_for('static', filename='images/favicon.png') }}"> {% block style_links %}{% endblock %}
+    <style>
+      {% block style %}
+      {% endblock %}
+    </style>
+  </head>
 
-        {% block style_links %} {% endblock %}
-        <style>
-            .spinner {
-                position: fixed;
-                top: 50%;
-                left: 50%;
-                margin-left: -50px; /* half width of the spinner gif */
-                margin-top: -50px; /* half height of the spinner gif */
-                text-align:center;
-                z-index:1234;
-                overflow: auto;
-                width: 100px; /* width of the spinner gif */
-                height: 102px; /*hight of the spinner gif +2px to fix IE8 issue */
-            }
+  <body>
 
-            .table {
-              font-size: 14px;
-            }
+    <!-- Top-level navbar -->
+    <nav class="navbar navbar-fixed-top navbar-inverse">
+      <div class="container">
+        <div class="navbar-header">
+          <!-- Hamburger button to display collapsed menu -->
+          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
 
-            .modal-content {
-              max-width: 1024px;
-            }
+          <!-- Brand name / logo -->
+          <a class="navbar-brand" href="/" class="logo-image">
+            <img style='height:100%;' src='{{ url_for("static", filename = "images/logo-white.svg")}}' />
+          </a>
+        </div>
 
-            {% block style %} {% endblock %}
+        <!-- Navigation items -->
+        <div id="navbar" class="navbar-collapse collapse">
 
-          </style>
-
-
-    </head>
-
-
-    <body>
-
-        <div class="navbar navbar-knowledge" role="navigation">
-            <div class="container page-container">
-                <a  href="/" aria-selected="false" class="logo-image navbar-text" style='margin-top:16px; margin-left: -7px'>
-                    <img width="125" src='{{ url_for("static", filename = "images/logo-white.svg")}}'></img>
-                </a>
-                <a id="feed_tab" href="/" aria-selected="false" class="navbar-text" style='margin-top:18px'>
-                    Home
-                </a>
-                <a id="favorites_tab" href="/favorites" aria-selected="false" class="navbar-text" style='margin-top:18px'>
-                    Favorites
-                </a>
-                <a id="help_tab" href="/about" aria-selected="false" class="navbar-text" style='margin-top:18px'>
-                    About
-                </a>
-                <a id="stats_tab" href="/stats" aria-selected="false" class="navbar-text" style='margin-top:18px'>
-                    Stats
-                </a>
-                <a id="webposts_tab" href="/create"
-                   class="btn btn-primary navbar-text pull-right"
-                   style='border-radius:4px; margin-top:10px; margin-right:-10px; background-color: #00a699; color:white; border-color: #00a699'>
-                    Write a Post!
-                </a>
-                <div class="pull-right">
-                    <div class="form-group">
-                        <input class="form-control" id="searchbar" placeholder="Search for Knowledge" style="text-align:right">
-                    </div>
-                </div>
+          <!-- Search bar -->
+          <form class="navbar-form navbar-left searchbar" role="search" action="{{url_for('index.render_feed')}}">
+            <div class="input-group">
+              <input type="text" class="form-control" placeholder="Search" name="filters" id="searchbar" value="{% if feed_params and feed_params['filters'] %}{{ feed_params['filters'] }}{% endif %}">
+              <div class="input-group-btn">
+                <button class="btn btn-default" type="submit"><i class="glyphicon glyphicon-search"></i></button>
+              </div>
             </div>
+          </form>
+
+          <!-- "Write a Post" button -->
+          <a href="/create" class="btn btn-primary navbar-button">
+            Write a Post!
+          </a>
+
+          <!-- Drop down menu to surface less used links on large screens -->
+          <ul class="nav navbar-nav navbar-right visible-sm-block visible-md-block visible-lg-block">
+            <li class="dropdown">
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="true"><span class="caret"></span></a>
+              <ul class="dropdown-menu">
+                <li class="dropdown-header">Logged in as <em>{{name}}</em></li>
+                <li><a href="/feed?authors={{username}}">My Posts</a></li>
+                <li><a href="/favorites">My Favorites</a></li>
+                <li role="separator" class="divider"></li>
+                <li class="dropdown-header">Site Features</li>
+                <li><a href="/stats">Stats</a></li>
+                <li><a href="/about">About</a></li>
+              </ul>
+            </li>
+          </ul>
+
+          <!-- Expose the same links as above in the collapsed navbar header -->
+          <ul class="nav navbar-nav navbar-right visible-xs-block">
+            <li class="dropdown-header">Logged in as <em>{{name}}</em></li>
+            <li><a href="/feed?authors={{username}}">My Posts</a></li>
+            <li><a href="/favorites">My Favorites</a></li><li role="separator" class="divider"></li>
+            <li class="dropdown-header">Site Features</li>
+            <li><a id="stats_tab" href="/stats">Stats</a></li>
+            <li><a id="help_tab" href="/about">About</a></li>
+          </ul>
+
         </div>
+      </div>
+    </nav>
 
-        <div class="container page-container">
-
-            {% block content %} {% endblock %}
-
+    <!-- Main content place holder, with a sidebar on both the left and right,
+         which collapse to form a single column on smaller screens. -->
+    <div class="container-fluid page-container">
+      <div class='row'>
+        <!-- Left sidebar -->
+        <div class='col-lg-2'>
+          <div class='side-panel' id='panel-left'>
+            {% block panel_left %}{% endblock %}
+          </div>
         </div>
-
-        <div class="footer">
-            Served with <span class="glyphicon glyphicon-heart"></span> by <a href="https://github.com/airbnb/knowledge-repo">Knowledge Repo</a> <a {% if version_revision %}title='{{version_revision}}'{% endif %} href="https://github.com/airbnb/knowledge-repo/releases/tag/v{{ version }}">{{ version }}</a><br />
-            <i title="Last checked for updates: {{last_index_check}}">Last indexed: {{last_index}}</i>
+        <!-- Main content placeholder -->
+        <div class='col-lg-8' id='panel-main'>
+          {% block content %} {% endblock %}
         </div>
+        <!-- Right sidebar -->
+        <div class='col-lg-2'>
+          <div class='side-panel' id='panel-right'>
+            {% block panel_right %}{% endblock %}
+          </div>
+        </div>
+      </div>
+    </div>
 
-        {% block scripts %}
-        <script type='text/javascript'>
-            $("#searchbar")[0].setSelectionRange(1000, 1000);
+    <div class="footer">
+      Served with <span class="glyphicon glyphicon-heart"></span> by <a href="https://github.com/airbnb/knowledge-repo">Knowledge Repo</a> <a {% if version_revision %}title='{{version_revision}}' {% endif %} href="https://github.com/airbnb/knowledge-repo/releases/tag/v{{ version }}">{{ version }}</a>
+      <br />
+      <i title="Last checked for updates: {{last_index_check}}">Last indexed: {{last_index}}</i>
+    </div>
 
-            $('#searchbar').typeahead({
-                hint: false,
-                highlight: true,
-                minLength: 1
-              },
-              {
-                name: 'knowledge_posts',
-                limit: 10,
-                display: function (item) {
-                  return item.title + " - " + item.author;
-                },
-                templates: {
-                  empty: Handlebars.compile(
-                    '<div class="tt-not-found">' +
-                      'Unable to find any posts that match the current query' +
-                      '</div>'
-                  ),
-                  suggestion: function(data) {
-                    return '<p style="overflow-wrap:break-word"><strong class="text-rausch">' + data.title + '</strong> – ' + data.author + '</p>';
-                  }
-                },
-                source: function(q, sync, async) {
-                  $.ajax('/ajax/index/typeahead?search=' + q,
-                  {
-                    success: function(data,status){ async(JSON.parse(data)); }
-                  })
-                }
-              });
+    <!-- Placeholder for additional ad-hoc scripts. -->
+    {% block scripts %}
+    {% endblock %}
 
-
-            $('#searchbar').bind('typeahead:select', function(obj, datum, name) {
-              window.location = '/post/'+encodeURIComponent(datum.path);
-            });
-
-            $('#searchbar').keypress(function(event){
-              var keycode = (event.keyCode ? event.keyCode : event.which);
-              if(keycode == '13'){
-                var path = document.location.pathname;
-                window.location = '/feed?filters=' + $('#searchbar').val()
-              }
-            });
-
-            var padding = $('.tt-menu').outerWidth()
-            $('.tt-menu').width($('#searchbar').width() + padding + "px")
-
-        </script>
-        {% endblock %}
-
-    </body>
+  </body>
 
 </html>

--- a/knowledge_repo/app/templates/index-base.html
+++ b/knowledge_repo/app/templates/index-base.html
@@ -20,7 +20,6 @@
 
     {% if autohide and page_count > 1 %}
       {% set page_nums = pagination_pages(current_page=page, page_count=page_count, max_pages=max_pages, extremes=extremes) %}
-
       <div class='pagination-bar' role="group">
         <a href="{{ "#" if (page == 1) else modify_query(start=(page-2)*results) }}" class="pagination-stepper{% if page == 1 %} disabled{% endif %}"{% if page == 1 %} onclick="return false;"{% endif %}>
           <i class="glyphicon glyphicon-chevron-left"></i>
@@ -40,13 +39,10 @@
 
     {% endif %}
   {% endif %}
-
 {% endmacro %}
 
-{% block title %} Knowledge Repo {% endblock %}
-
 {% block content %}
-
+  <!-- Index rendering mode switch -->
   <div class="row">
     <div class="col-md-5">
       <div class="btn-group btn-group-justified index-view-btn-group" role="group">
@@ -65,22 +61,24 @@
       </div>
     </div>
 
+    {# Show pagination at top unless showing clusters. #}
     {% if request.endpoint != 'index.render_cluster' %}
-    <div class='pull-right'>
+    <div class='pull-right visible-md-block visible-lg-block'>
       {{ pagination(max_pages=5, extremes=False) }}
     </div>
     {% endif %}
 
   </div>
 
+  <!-- Container for index items -->
   <div class="col-12">
     {% block inner_content %}
     {% endblock %}
   </div>
 
-
-{{ pagination(max_pages=10) }}
+  {# Show pagination at bottom of page unless showing clusters. #}
+  {% if request.endpoint != 'index.render_cluster' %}
+  {{ pagination(max_pages=10) }}
+  {% endif %}
 
 {% endblock %}
-
-

--- a/knowledge_repo/app/templates/markdown-base.html
+++ b/knowledge_repo/app/templates/markdown-base.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 
-{% block title %} Knowledge {% endblock %}
+{% if title %}
+{% block title %}{{title}}{% endblock %}
+{% endif %}
 
 {% block style_links %}
 {{ super() }}

--- a/knowledge_repo/app/templates/markdown-base.html
+++ b/knowledge_repo/app/templates/markdown-base.html
@@ -30,6 +30,11 @@
 <a href='{{url_for('posts.download')}}?type=source&post={{post_path|urlencode}}&path={{file|urlencode}}' class="btn btn-primary btn-download">{{ file }}</a>
 {% endfor %}
 {% endif %}
+
+{% if is_author and is_private %}
+<span class='section'>Post Permissions</span>
+<a href='post_groups?post_id={{post_id}}'>Add permissions for users</a>
+{% endif %}
 {% endblock %}
 
 {% block content %}
@@ -42,28 +47,21 @@
                 {% if is_author and show_webeditor_button %}
                 <li role="presentation"><a href="/edit/{{post_path}}">Edit</a></li>
                 {% endif %}
+                {% if not webeditor_buttons and data_repo_git_root %}
+                  <a href='{{ data_repo_git_root}}/blob/master/{{post_path|urlencode}}'
+                     target="_blank"
+                     style='padding-right:10px;'>
+                    View on Github
+                    <i class='glyphicon glyphicon-new-window'></i>
+                  </a>
+                  <a href='{{ data_repo_git_root}}/edit/master/{{post_path|urlencode}}' target="_blank">
+                    Edit on Github
+                    <i class='glyphicon glyphicon-new-window'></i>
+                  </a>
+                {% endif %}
             </ul>
         </div>
       </div>
-      <!-- <div class="row col-md-12">
-        {% if not webeditor_buttons and data_repo_git_root %}
-          <a href='{{ data_repo_git_root}}/blob/master/{{post_path|urlencode}}'
-             target="_blank"
-             style='padding-right:10px;'>
-            View on Github
-            <i class='glyphicon glyphicon-new-window'></i>
-          </a>
-          <a href='{{ data_repo_git_root}}/edit/master/{{post_path|urlencode}}' target="_blank">
-            Edit on Github
-            <i class='glyphicon glyphicon-new-window'></i>
-          </a>
-        {% endif %}
-        {% if is_author and is_private %}
-        <a href='post_groups?post_id={{post_id}}'>
-          Add permissions for users
-        </a>
-        {% endif %}
-      </div> -->
     </div>
 {% endblock %}
 

--- a/knowledge_repo/app/templates/markdown-base.html
+++ b/knowledge_repo/app/templates/markdown-base.html
@@ -7,54 +7,43 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/pages/markdown-base.css')}}">
 {% endblock %}
 
-{% block content %}
+{% block panel_left %}
+{% if toc %}
+<div class='visible-lg-block'>
+<span class='section'>Table of Contents</span>
+{{toc|replace('<ul>', '<ul class="nav">')|replace('<div class="toc">','<div class="toc" id="toc">')|safe}}
+</div>
+{% endif %}
+{% endblock %}
 
-    <br>
+{% block panel_right %}
+<span class='section'>Downloads</span>
+<!-- TODO: Enable this once portable knowledge posts are integrated into scripts
+<a href="{{url_for('posts.download')}}?type=kp&post={{post_path}}" class="btn btn-primary btn-download" style='display: block;'>Portable Knowledge Post</a>
+-->
+<a href="{{url_for('posts.download')}}?type=zip&post={{post_path|urlencode}}" class="btn btn-primary btn-download" style='display: block;'>ZIP Archive</a>
+{% if downloads %}
+<span class='subsection'>Source Files</span>
+{% for file in downloads %}
+<a href='{{url_for('posts.download')}}?type=source&post={{post_path|urlencode}}&path={{file|urlencode}}' class="btn btn-primary btn-download">{{ file }}</a>
+{% endfor %}
+{% endif %}
+{% endblock %}
+
+{% block content %}
     <div class="container-fluid">
       <div class="row">
-        <div class="col-md-6">
-          <div class="btn-group" role="group">
-            <button type="button" class="btn btn-default btn-rendered">
-              View Post
-            </button>
-            <button type="button" class="btn btn-default btn-raw">
-              View Raw Markdown
-            </button>
-            {% if is_author and show_webeditor_button %}
-            <button type="button" class="btn btn-default btn-webeditor">
-              View post in webeditor
-            </button>
-            {% endif %}
-          </div>
-        </div>
-        <div class="col-md-2">
-        </div>
-        <div class="col-md-4 text-right">
-          {% if page_views >= 0 %}
-            <i class="glyphicon glyphicon-eye-open" id="pageview_stats" style='color: #9CA299'></i>
-            <div id="pageview_stats" style="display: inline-block">
-              Viewed {{ page_views }} times by {{ unique_views }} different users
-            </div>
-          {% endif %}
-          {% if likes %}
-            <i class="glyphicon glyphicon-heart glyphicon-clickable pop" style="font-size:16pt" id="tooltip-unlike" data-placement="bottom"
-             data-trigger="#tooltip-like"
-             data-container="body"
-             data-toggle="popover"
-             data-content='<div>Unlike This Post</div>'></i>
-          {% else %}
-            <i class="glyphicon glyphicon-heart-empty glyphicon-clickable pop" style="font-size:16pt" id="tooltip-like" data-placement="bottom"
-             data-trigger="#tooltip-like"
-             data-container="body"
-             data-toggle="popover"
-             data-content='<div>Like This Post</div>'></i>
-          {% endif %}
-          {% if total_likes %}
-          + {{ total_likes }}
-          {% endif %}
+        <div class="col-md-12">
+            <ul class="nav nav-tabs" style='margin-bottom: -1px; position: relative; z-index: 1;'>
+                <li role="presentation" class="tab-rendered"><a href="?">HTML</a></li>
+                <li role="presentation" class="tab-raw"><a href="?render=raw">Markdown</a></li>
+                {% if is_author and show_webeditor_button %}
+                <li role="presentation"><a href="/edit/{{post_path}}">Edit</a></li>
+                {% endif %}
+            </ul>
         </div>
       </div>
-      <div class="row col-md-12">
+      <!-- <div class="row col-md-12">
         {% if not webeditor_buttons and data_repo_git_root %}
           <a href='{{ data_repo_git_root}}/blob/master/{{post_path|urlencode}}'
              target="_blank"
@@ -72,7 +61,7 @@
           Add permissions for users
         </a>
         {% endif %}
-      </div>
+      </div> -->
     </div>
 {% endblock %}
 
@@ -80,6 +69,7 @@
 {{ super() }}
 
 <script src="{{ url_for('static', filename='js/tooltips.js') }}" type="text/javascript"></script>
+
 <script type="text/javascript">
 $("document").ready(function(){
   var is_webeditor = false;
@@ -91,21 +81,6 @@ $("document").ready(function(){
   var post_path = "{{ post_path }}"
   var data_repo_github_root = "{{ data_repo_git_root }}"
   tooltipsJx.initializeTooltips(is_webeditor, post_id, id, data_repo_github_root);
-
-  $(".btn-rendered").on("click", function(){
-    document.location.href = "/post/" + encodeURI(post_path);
-  })
-
-  $(".btn-raw").on("click", function(){
-    document.location.href = "/post/" + encodeURI(post_path) + "?render=raw";
-  })
-
-  $(".btn-webeditor").on("click", function(){
-    document.location.href = "/edit/" + encodeURI(post_path);
-  })
 });
-
 </script>
-
-
 {% endblock %}

--- a/knowledge_repo/app/templates/markdown-presentation.html
+++ b/knowledge_repo/app/templates/markdown-presentation.html
@@ -1,7 +1,5 @@
 {% extends "markdown-base.html" %}
 
-{% block title %} Knowledge {% endblock %}
-
 {% block content %}
 
     {{ super() }}
@@ -45,4 +43,3 @@
 </script>
 
 {% endblock %}
-

--- a/knowledge_repo/app/templates/markdown-raw.html
+++ b/knowledge_repo/app/templates/markdown-raw.html
@@ -4,11 +4,8 @@
 
 {% block content %}
 {{ super() }}
-<div>
-  <h1> {{ post_path }} </h1>
-  <div style="white-space: pre-wrap;">
+<div class="renderedMarkdown">
   {{ raw_post | safe }}
-  </div>
 </div>
 {% endblock %}
 
@@ -16,5 +13,6 @@
 {{ super() }}
 <script>
 $(".btn-raw").addClass("btn-active")
+$(".tab-raw").addClass('active');
 </script>
 {% endblock %}

--- a/knowledge_repo/app/templates/markdown-raw.html
+++ b/knowledge_repo/app/templates/markdown-raw.html
@@ -10,7 +10,6 @@
 {% block scripts %}
 {{ super() }}
 <script>
-$(".btn-raw").addClass("btn-active")
 $(".tab-raw").addClass('active');
 </script>
 {% endblock %}

--- a/knowledge_repo/app/templates/markdown-raw.html
+++ b/knowledge_repo/app/templates/markdown-raw.html
@@ -1,7 +1,5 @@
 {% extends "markdown-base.html" %}
 
-{% block title %} Markdown {% endblock %}
-
 {% block content %}
 {{ super() }}
 <div class="renderedMarkdown">

--- a/knowledge_repo/app/templates/markdown-rendered.html
+++ b/knowledge_repo/app/templates/markdown-rendered.html
@@ -11,14 +11,32 @@
 
     {{ super() }}
 
-    <div class='container-fluid'>
-        <div class="row">
-            <div class="col-md-12">
-                <div class="renderedMarkdown">
-                    {{ html|safe }}
-                </div>
-            </div>
-        </div>
+    <div class="renderedMarkdown">
+        <span class='stats' style='position: absolute; right: 0px; padding: 5px; color: #aaa; top: 0px;'>
+            {% if page_views >= 0 %}
+              <i class="glyphicon glyphicon-eye-open" id="pageview_stats" style='color: #9CA299'></i>
+              <div id="pageview_stats" style="display: inline-block">
+                Viewed {{ page_views }} times by {{ unique_views }} different users
+              </div>
+            {% endif %}
+            {% if likes %}
+              <i class="glyphicon glyphicon-heart glyphicon-clickable pop" style="font-size:16pt; vertical-align: top;" id="tooltip-unlike" data-placement="bottom"
+               data-trigger="#tooltip-like"
+               data-container="body"
+               data-toggle="popover"
+               data-content='<div>Unlike This Post</div>'></i>
+            {% else %}
+              <i class="glyphicon glyphicon-heart-empty glyphicon-clickable pop" style="font-size:16pt; vertical-align: top;" id="tooltip-like" data-placement="bottom"
+               data-trigger="#tooltip-like"
+               data-container="body"
+               data-toggle="popover"
+               data-content='<div>Like This Post</div>'></i>
+            {% endif %}
+            {% if total_likes %}
+            + {{ total_likes }}
+            {% endif %}
+        </span>
+        {{ html|safe }}
     </div>
 
     <div class="container-fluid">
@@ -70,7 +88,6 @@
           </br>
         </div>
     </div>
-  </div>
 {% endblock %}
 
 {% block scripts %}
@@ -100,6 +117,13 @@
 $(document).on('ready', function(){
   // Make the Rendered Markdown Button active
   $(".btn-rendered").addClass("btn-active");
+  $(".tab-rendered").addClass('active');
+
+  // Activate scrollspy for dynamic highlighting the table of contents
+  $('body').scrollspy({ target: '.toc', offset: 71 })
+
+  // Wrap all tables in a div to allow for centering with overscroll
+  $('.renderedMarkdown table').wrap("<div class='table-wrapper'></div>")
 
   // Initialize headers
   helpersJx.linkifyHeaders();

--- a/knowledge_repo/app/templates/markdown-rendered.html
+++ b/knowledge_repo/app/templates/markdown-rendered.html
@@ -114,7 +114,6 @@
 <script>
 $(document).on('ready', function(){
   // Make the Rendered Markdown Button active
-  $(".btn-rendered").addClass("btn-active");
   $(".tab-rendered").addClass('active');
 
   // Activate scrollspy for dynamic highlighting the table of contents

--- a/knowledge_repo/app/templates/markdown-rendered.html
+++ b/knowledge_repo/app/templates/markdown-rendered.html
@@ -1,7 +1,5 @@
 {% extends "markdown-base.html" %}
 
-{% block title %} Knowledge {% endblock %}
-
 {% block style_links %}
 {{ super() }}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/codehilite-friendly.css')}}">

--- a/knowledge_repo/app/templates/stats.html
+++ b/knowledge_repo/app/templates/stats.html
@@ -1,9 +1,9 @@
-{% extends "index-base.html" %}
+{% extends "base.html" %}
 
 
-{% block header %} Stats  {% endblock %}
+{% block title %}Stats{% endblock %}
 
-{% block inner_content %}
+{% block content %}
 
   <br>
     <div class="panel">

--- a/knowledge_repo/app/utils/emails.py
+++ b/knowledge_repo/app/utils/emails.py
@@ -106,7 +106,6 @@ def send_subscription_email(post, tag):
 
     for user in recipient_users:
         # mark email as sent just before you send the email
-        print(subject, post_text)
         email_sent = Email(user_id=user.id,
                            trigger_id=tag.id,
                            trigger_type='subscription',

--- a/knowledge_repo/app/utils/emails.py
+++ b/knowledge_repo/app/utils/emails.py
@@ -106,6 +106,7 @@ def send_subscription_email(post, tag):
 
     for user in recipient_users:
         # mark email as sent just before you send the email
+        print(subject, post_text)
         email_sent = Email(user_id=user.id,
                            trigger_id=tag.id,
                            trigger_type='subscription',

--- a/knowledge_repo/app/utils/render.py
+++ b/knowledge_repo/app/utils/render.py
@@ -1,6 +1,7 @@
 import sys
 
 import markdown
+import pygments
 from flask import url_for
 from knowledge_repo.post import KnowledgePost
 
@@ -67,6 +68,12 @@ def render_post_raw(post):
     else:
         raw_post = post.text.encode('ascii', 'ignore')
 
+    raw_post = pygments.highlight(
+        code=raw_post,
+        lexer=pygments.lexers.get_lexer_by_name('md'),
+        formatter=pygments.formatters.get_formatter_by_name('html')
+    )
+
     # NOTE: `str.encode()` returns a `bytes` object in Python 3
     if sys.version_info.major >= 3:
         return raw_post.decode('ascii', 'ignore')
@@ -77,15 +84,21 @@ def render_post(post):
     """
     Renders the markdown as html
     """
+    from knowledge_repo.converters.html import HTMLConverter
+
     def intra_knowledge_urlmapper(name, url):
         if name == 'a' and url.startswith('knowledge:'):
             return url_for('posts.render', path=url.split('knowledge:')[1]).replace('%2F', '/')  # Temporary fix before url revamp
         return None
 
-    html = render_post_header(post) + (post if isinstance(post, KnowledgePost) else post.kp).to_string('html',
-                                                                                                       skip_headers=True,
-                                                                                                       urlmappers=[intra_knowledge_urlmapper])
-    return html
+    md, html = HTMLConverter(post if isinstance(post, KnowledgePost) else post.kp)._render_markdown(skip_headers=True, urlmappers=[intra_knowledge_urlmapper])
+
+    html = render_post_header(post) + html
+
+    return {
+        "html": html,
+        "toc": md.toc
+    }
 
 
 def render_comment(comment):

--- a/knowledge_repo/app/utils/render.py
+++ b/knowledge_repo/app/utils/render.py
@@ -80,7 +80,7 @@ def render_post_raw(post):
     return raw_post
 
 
-def render_post(post):
+def render_post(post, with_toc=False):
     """
     Renders the markdown as html
     """
@@ -95,10 +95,12 @@ def render_post(post):
 
     html = render_post_header(post) + html
 
-    return {
-        "html": html,
-        "toc": md.toc
-    }
+    if with_toc:
+        return {
+            "html": html,
+            "toc": md.toc
+        }
+    return html
 
 
 def render_comment(comment):

--- a/knowledge_repo/converters/html.py
+++ b/knowledge_repo/converters/html.py
@@ -156,9 +156,10 @@ class HTMLConverter(KnowledgePostConverter):
     def init(self):
         self.kp_images = self.kp.read_images()
 
-    def to_string(self, skip_headers=False, images_base64_encode=True, urlmappers=[]):
+    def _render_markdown(self, skip_headers=False, images_base64_encode=True, urlmappers=[]):
         """
-        Renders the markdown as html
+        Returns the `Markdown` instance as well as the rendered html output
+        as a tuple: (`Markdown`, str).
         """
         # Copy urlmappers locally so we can modify it without affecting global
         # state
@@ -174,9 +175,18 @@ class HTMLConverter(KnowledgePostConverter):
         if not skip_headers:
             html += self.render_headers()
 
-        html += markdown.Markdown(extensions=MARKDOWN_EXTENSTIONS).convert(self.kp.read())
+        md = markdown.Markdown(extensions=MARKDOWN_EXTENSTIONS)
+        html += md.convert(self.kp.read())
 
-        return self.apply_url_remapping(html, urlmappers)
+        html = self.apply_url_remapping(html, urlmappers)
+
+        return md, html
+
+    def to_string(self, skip_headers=False, images_base64_encode=True, urlmappers=[]):
+        """
+        Renders the markdown as html
+        """
+        return self._render_markdown[1]
 
     def apply_url_remapping(self, html, urlmappers):
         patterns = {

--- a/knowledge_repo/converters/pkp.py
+++ b/knowledge_repo/converters/pkp.py
@@ -37,8 +37,6 @@ class IpynbFormat(KnowledgePostConverter):
 
         zf.close()
 
-     #   raise RuntimeError("Portable Knowledge Post is invalid!")
-
 
 class NBConvertExporter(Exporter):
 

--- a/knowledge_repo/converters/pkp.py
+++ b/knowledge_repo/converters/pkp.py
@@ -1,0 +1,38 @@
+import zipfile
+import io
+
+from ..converter import KnowledgePostConverter
+
+
+class IpynbFormat(KnowledgePostConverter):
+    _registry_keys = ['kp']
+
+    def to_file(self, filename):
+        zf = zipfile.ZipFile(filename, 'w')
+
+        for ref in self.kp._dir():
+            zf.writestr(ref, self.kp._read_ref(ref))
+
+        zf.close()
+
+    def to_string(self):
+        data = io.BytesIO()
+        zf = zipfile.ZipFile(data, 'w')
+
+        for ref in self.kp._dir():
+            zf.writestr(ref, self.kp._read_ref(ref))
+
+        zf.close()
+        data.seek(0)
+        return data.read()
+
+    def from_file(self, filename):
+        zf = zipfile.ZipFile(filename, 'r')
+
+        for ref in zf.namelist():
+            with zf.open(ref) as f:
+                self.kp._write_ref(ref, f.read())
+
+        zf.close()
+
+     #   raise RuntimeError("Portable Knowledge Post is invalid!")

--- a/knowledge_repo/converters/pkp.py
+++ b/knowledge_repo/converters/pkp.py
@@ -7,7 +7,7 @@ from ..converter import KnowledgePostConverter
 
 
 class IpynbFormat(KnowledgePostConverter):
-    _registry_keys = ['kp']
+    _registry_keys = ['kp', 'zip']
 
     def to_file(self, filename):
         zf = zipfile.ZipFile(filename, 'w')

--- a/knowledge_repo/converters/pkp.py
+++ b/knowledge_repo/converters/pkp.py
@@ -1,6 +1,8 @@
 import zipfile
 import io
 
+from nbconvert.exporters.exporter import Exporter
+
 from ..converter import KnowledgePostConverter
 
 
@@ -36,3 +38,30 @@ class IpynbFormat(KnowledgePostConverter):
         zf.close()
 
      #   raise RuntimeError("Portable Knowledge Post is invalid!")
+
+
+class NBConvertExporter(Exporter):
+
+    def from_notebook_node(self, nb, resources=None, **kw):
+        """
+        Convert a notebook from a notebook node instance.
+        Parameters
+        ----------
+        nb : :class:`~nbformat.NotebookNode`
+          Notebook node (dict-like with attr-access)
+        resources : dict
+          Additional resources that can be accessed read/write by
+          preprocessors and filters.
+        `**kw`
+          Ignored
+        """
+        nb_copy = copy.deepcopy(nb)
+        resources = self._init_resources(resources)
+
+        if 'language' in nb['metadata']:
+            resources['language'] = nb['metadata']['language'].lower()
+
+        # Preprocess
+        nb_copy, resources = self._preprocess(nb_copy, resources)
+
+        return nb_copy, resources

--- a/setup.py
+++ b/setup.py
@@ -79,5 +79,10 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
     ],
-    cmdclass={'install_scripts': install_scripts_windows_wrapper}
+    cmdclass={'install_scripts': install_scripts_windows_wrapper},
+    entry_points={
+        'nbconvert.exporters': [
+            'knowledge_post = knowledge_repo.converters.pkp:NBConvertExporter',
+        ],
+    }
 )


### PR DESCRIPTION
This patch set brings some much-needed love to the user interface to the knowledge repo, addessing #45, #257, #287 and #291 . In particular, it:

- Improves the appearance of the top bar, and makes it fixed and always available.
<img width="1425" alt="screen shot 2017-07-03 at 11 49 47 am" src="https://user-images.githubusercontent.com/124910/27804860-0ed63c50-5fe6-11e7-87a3-bd604ba2f009.png">

- Makes the entire interface responsive (you will need to play around with resizing windows to see the full benefit of this work)
<img width="405" alt="screen shot 2017-07-03 at 11 50 02 am" src="https://user-images.githubusercontent.com/124910/27804877-258b8e64-5fe6-11e7-871f-003a69fd84c5.png">
<img width="405" alt="screen shot 2017-07-03 at 11 50 14 am" src="https://user-images.githubusercontent.com/124910/27804880-29849dda-5fe6-11e7-84ab-e29814abbcff.png">

- Added support for responsive side-bars

- Posts are now rendered with an interactive table of contents and with download links (which are also responsive)
<img width="1425" alt="screen shot 2017-07-03 at 12 44 54 am" src="https://user-images.githubusercontent.com/124910/27804903-46f0be12-5fe6-11e7-8dd5-03954aafa471.png">

- Table theming is greatly improved, are rendered as centered and gracefully scroll when overflowed (based on the table styling used in Jupyter)

- Post title is used for window/tab/page title.

- Many other smaller user interface tweaks.

As part of this work, support was added for standalone ZIP representations of knowledge posts which will be leveraged more heavily in the future.

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
