### PR TITLE
[CLI] add quotes to message to enable easier path selection

### DIFF
--- a/scripts/knowledge_repo
+++ b/scripts/knowledge_repo
@@ -233,7 +233,7 @@ if args.action == 'create':
     if os.path.exists(args.filename):
         raise ValueError("File already exists at '{}'. Please choose a different filename and try again.".format(args.filename))
     shutil.copy(src, args.filename)
-    print("Created a {format} knowledge post template at {filename}.".format(format=args.format, filename=args.filename))
+    print("Created a {format} knowledge post template at '{filename}'.".format(format=args.format, filename=args.filename))
     sys.exit(0)
 
 # # Check which branches have local work


### PR DESCRIPTION
Description of changeset: 
This very simple PR is adding quotes to the post creation message. This prevents the terminal emulator's smart selection to select the final period. I used single quote to match the style of other messages in the CLI interface.

Test Plan: 
Modified locally and it did what I expected. 

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
