### PR TITLE
Fix reference path in Windows.

### DIFF
--- a/knowledge_repo/postprocessors/extract_images.py
+++ b/knowledge_repo/postprocessors/extract_images.py
@@ -1,4 +1,5 @@
 import os
+import posixpath
 import re
 import logging
 
@@ -104,7 +105,7 @@ class ExtractImages(KnowledgePostProcessor):
             return
         with open(path, 'rb') as f:
             kp.write_image(os.path.basename(path), f.read())
-        return os.path.join('images', os.path.basename(path))
+        return posixpath.join('images', os.path.basename(path))
 
     @classmethod
     def replace_image_locations(cls, md, offset, match, old_path, new_path):


### PR DESCRIPTION
In Windows, reference paths should still be indicated using posix/html-like path separators, otherwise images break for posts generated on Windows. This simple patch resolves this for all *new* posts. (This supersedes that #302 that added a hack later in the post rendering pipeline, and which could on occasion break urls containing `\`).

@zerogjoe @susanjo80: Can you verify that this resolves these issues for you?

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
