### PR TITLE
Update source paths from `orig_src` to `src`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ See the file itself for more detail.
 
 #### Knowledge Web Application Configuration
 
-Specify a configuration file when running the web application by adding the flag `--config path/to/config_file.py`. An example configuration file is provided [here](https://github.com/airbnb/knowledge-repo/blob/master/resources/server_config.py). 
+Specify a configuration file when running the web application by adding the flag `--config path/to/config_file.py`. An example configuration file is provided [here](https://github.com/airbnb/knowledge-repo/blob/master/resources/server_config.py).
 
 This configuration file lets you specify details specific to the web server. For instance, one can specify the database connection string or the request header that contains usernames. See the file itself for more detail.
 
@@ -390,6 +390,6 @@ A knowledge post is a directory, with the following structure:
 	<knowledge_post>
 		- knowledge.md
 		+ images/* [Optional]
-		+ orig_src/* [Optional; stores the original converted file]
+		+ src/* [Optional; stores the original source files]
 
-Images are automatically extracted from the local paths on your computer, and placed into images. `orig_src` contains the file(s) from which the knowledge post was converted from.
+Images are automatically extracted from the local paths on your computer, and placed into images. `src` contains the file(s) from which the knowledge post was converted from.

--- a/knowledge_repo/app/routes/posts.py
+++ b/knowledge_repo/app/routes/posts.py
@@ -112,7 +112,7 @@ def render(path):
                                table_id=None,
                                is_private=(post.private == 1),
                                is_author=is_author,
-                               downloads=list(post.kp._dir('orig_src/')) if permissions.post_download.can() else None)
+                               downloads=post.kp.src_paths if permissions.post_download.can() else None)
     return rendered
 
 
@@ -206,8 +206,9 @@ def download():
     elif resource_type == 'source':
         path = request.args.get('path', None)
         assert path is not None, "Source path not provided."
+        assert path in post.src_paths, "Provided reference is not a valid source path."
         return Response(
-            post.read_src(path),
+            post.read_ref(path),
             mimetype="application/octet-stream",
             headers={u"Content-disposition": "attachment; filename={}".format(os.path.basename(path))})
     else:

--- a/knowledge_repo/templates/repo_data_readme.md
+++ b/knowledge_repo/templates/repo_data_readme.md
@@ -115,7 +115,7 @@ Here is a full list of headers used in the YAML section of knowledge posts:
 
 ### Handling Images
 
-The knowledge repo's default behavior is to add the markdown's contents as is to your knowledge post git repository. If you do not have git LFS set up, it may be in your interest to have these images hosted on some type of cloud storage, so that pulling the repo locally isn't cumbersome. 
+The knowledge repo's default behavior is to add the markdown's contents as is to your knowledge post git repository. If you do not have git LFS set up, it may be in your interest to have these images hosted on some type of cloud storage, so that pulling the repo locally isn't cumbersome.
 
 Configuring the knowledge repository to strip out images and upload them to some cloud service looks like defining a KnowledgePostProcessor in the .knowledge_repo_config.py on the master branch of the repository; and then referencing it in the postprocessors configuration key. An example KnowledgePostProcessor that uploads images to S3 is provided in resources/extract_images_to_s3.py. Getting it working in your set up may require some tweaking, which we are happy to help with. Once configured, the postprocessor's registry key can be added to the knowledge post git repository's .knowledge_repo_config postprocessor list.
 
@@ -207,5 +207,4 @@ A knowledge post is a virtual directory, with the following structure:
 	<knowledge_post>
 		- knowledge.md
 		+ images/* [Optional]
-		+ orig_src/* [Optional; stores the original converted file]
-
+		+ src/* [Optional; stores the original source files]


### PR DESCRIPTION
With the current workflow, users are not supposed to directly modify the markdown, and so we expect that the source code should be in sync with the rendered format. This tight coupling will continue to strengthen in upcoming versions (with new tooling), so to avoid confusion, we here rename `orig_src` to `src` inside of posts. This patch maintains legacy accessing of `orig_src` paths for now.

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
