### PR TITLE
Automatically promote numerical tags to strings.

### DIFF
--- a/knowledge_repo/post.py
+++ b/knowledge_repo/post.py
@@ -1,6 +1,4 @@
 from __future__ import absolute_import
-from builtins import next
-from builtins import object
 import os
 import posixpath
 import re
@@ -11,6 +9,9 @@ import yaml
 import mimetypes
 import base64
 import uuid
+
+import six
+from builtins import next, object
 
 from .utils.encoding import encode, decode
 
@@ -283,6 +284,8 @@ class KnowledgePost(object):
         for key, value in headers.copy().items():
             if isinstance(value, datetime.date):
                 headers[key] = datetime.datetime.combine(value, datetime.time(0))
+            if key == 'tags' and isinstance(value, list):
+                headers[key] = [str(v) if six.PY3 else unicode(v) for v in value]
         return headers
 
     @headers.setter

--- a/tests/test_posts/numerical_tags.ipynb
+++ b/tests/test_posts/numerical_tags.ipynb
@@ -1,0 +1,50 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "title: \"Numerical tags automatically get upgraded to strings!\"\n",
+    "authors:\n",
+    " - resident_father\n",
+    "created_at: 2017-03-22 00:00:00\n",
+    "updated_at: 2017-03-23 00:00:00\n",
+    "tags:\n",
+    " - 2017\n",
+    " - awesome\n",
+    "tldr: |\n",
+    "    In the past, numerical tags not encapsulated in quotes broke the knowledge repository... but no longer!\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There's nothing more to add!"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Fixes site breaking when numerical tags are present (fixes #294).

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
