### PR TITLE
Improve indexing by separating timing into separate thread

### DIFF
--- a/knowledge_repo/app/config_defaults.py
+++ b/knowledge_repo/app/config_defaults.py
@@ -139,6 +139,44 @@ def prepare_repo(repo):
 
 
 # ---------------------------------------------------
+# Repository Indexing configuration
+# ---------------------------------------------------
+# The Knowedge Repo updates the index of available posts on a regular basis.
+# If the database is not thread-safe (i.e. in the case of SQLite), then the
+# index will be updated on the main thread before every request that is more
+# than `INDEX_INTERVAL` seconds after the last sync completed. Otherwise,
+# indexing will occur every `INDEX_INTERVAL` seconds after the previous sync.
+# Syncing is designed to be compatible with multiple instances of the Knowledge
+# Repo connected to the same database, accross multiple machines and/or
+# processes; and so a global indexing lock is employed. When a sync begins,
+# a sync lock is put in place and the responsible process is considered to be
+# the primary agent responsible for syncing until its last update is longer than
+# `INDEXING_TIMEOUT` seconds, whereby the lock is ceded to the next requesting
+# process. Note that `INDEXING_INTERVAL` must be larger than `INDEXING_TIMEOUT`
+# or strange things might begin to happen.
+INDEXING_INTERVAL = 5 * 60  # 5 minutes
+INDEXING_TIMEOUT = 10 * 60  # 10 minutes
+
+# Whether an index operation should update repositories
+INDEXING_UPDATES_REPOSITORIES = True
+
+# Whether repositories should be updated even without a sync lock (in which case
+# the repositories will be updated on the sync timers, even if the relevant
+# process/thread does not have a lock on updating the index). This is useful in
+# context of multiple Knowledge Repo servers working together to serve the
+# repositories across multiple machines, which each require repository syncing.
+# Disable this if (for some reason) you have multiple Knowledge Repo servers
+# running on the same machine, and you want to avoid potential clashes. This
+# key is ignored if `INDEXING_UPDATES_REPOSITORIES` is False
+INDEXING_UPDATES_REPOSITORIES_WITHOUT_LOCK = True
+
+# In some cases you may want to disable indexing entirely, which is currently
+# only ever used by the Knowledge Post previewer. Disabling the index means that
+# posts will not be discoverable, but if know the path in the repository you can
+# view the post with a direct link.
+INDEXING_ENABLED = True
+
+# ---------------------------------------------------
 # Flask Mail Configuration
 # Refer to https://pythonhosted.org/flask-mail/
 # Unless specified, upstream defaults are used as indicated

--- a/knowledge_repo/app/deploy/flask.py
+++ b/knowledge_repo/app/deploy/flask.py
@@ -11,6 +11,6 @@ class FlaskDeployer(KnowledgeDeployer):
             debug=app.config['DEBUG'],
             host=self.host,
             port=self.port,
-            threaded=app.supports_threads,
+            threaded=app.check_thread_support(),
             **kwargs
         )

--- a/knowledge_repo/app/deploy/gunicorn.py
+++ b/knowledge_repo/app/deploy/gunicorn.py
@@ -33,6 +33,6 @@ class GunicornDeployer(BaseApplication, KnowledgeDeployer):
         return self.builder_func()
 
     def run(self):
-        if not self.app.supports_threads:
+        if not self.app.check_thread_support():
             raise RuntimeError("Database configuration is not suitable for deployment (not thread-safe).")
         return BaseApplication.run(self)

--- a/knowledge_repo/app/deploy/uwsgi.py
+++ b/knowledge_repo/app/deploy/uwsgi.py
@@ -15,7 +15,7 @@ class uWSGIDeployer(KnowledgeDeployer):
     COMMAND = u"uwsgi --http {socket} --plugin python --wsgi-file {path} --callable app --master --processes {processes} --threads {threads} --uid --gid"
 
     def run(self):
-        if not self.app.supports_threads:
+        if not self.app.check_thread_support():
             raise RuntimeError("Database configuration is not suitable for deployment (not thread-safe).")
 
         tmp_dir = self.write_temp_files()

--- a/knowledge_repo/app/index.py
+++ b/knowledge_repo/app/index.py
@@ -1,12 +1,17 @@
 from __future__ import absolute_import
+
+import atexit
 import logging
 import datetime
+import multiprocessing
+import os
 import threading
+import time
 from builtins import str
 from flask import has_app_context
 
 from .proxies import db_session, current_repo, current_app
-from .models import Post, IndexMetadata
+from .models import ErrorLog, Post, IndexMetadata
 from .utils.emails import send_subscription_emails
 from .utils.search import get_keywords
 from .utils.time import time_since
@@ -19,8 +24,57 @@ LOCKED = CHECKED = '1'
 UNLOCKED = '0'
 
 
+def set_up_indexing_timers(app):
+    if not app.config['INDEXING_ENABLED']:
+        return False
+
+    if app.check_thread_support(check_index=True, check_repositories=app.config['INDEXING_UPDATES_REPOSITORIES']):
+        if os.environ['KNOWLEDGE_REPO_MASTER_UUID'] != app.uuid:
+            logger.info("Not spawning index-sync timers for non-master application instance: {}".format(app.uuid))
+            return
+
+        def index_watchdog(app):
+            while True:
+                if not hasattr(app, 'sync_thread') or not app.sync_thread.is_alive():
+                    logger.warning("Master indexing thread has died. Restarting...")
+                    with app.app_context():
+                        app.sync_thread = multiprocessing.Process(target=index_sync_loop, args=(app,))
+                        app.sync_thread.start()
+                time.sleep(app.config['INDEXING_TIMEOUT'])
+
+        def index_sync_loop(app):
+            while True:
+                with app.app_context():
+                    update_index(check_timeouts=False)
+                time.sleep(app.config['INDEXING_INTERVAL'])
+
+        app.index_watchdog = multiprocessing.Process(target=index_watchdog, args=(app,))
+        app.index_watchdog.start()
+    else:
+        @app.before_request
+        def update_index_if_required():
+            update_index()
+
+
+def acquire_index_lock():
+    if IndexMetadata.get('lock', 'master_check', None) is None:
+        try:
+            IndexMetadata.set('lock', 'master_check', current_app.uuid)
+            db_session.commit()
+            if (
+                IndexMetadata.get('lock', 'index_master') == current_app.uuid or
+                time_since(IndexMetadata.get_last_update('lock', 'index_master'), default=current_app.config["INDEXING_TIMEOUT"] + 1) > current_app.config["INDEXING_TIMEOUT"]
+            ):
+                IndexMetadata.set('lock', 'index_master', current_app.uuid)  # Update/set lock and update timestamp
+                return True
+        finally:
+            IndexMetadata.set('lock', 'master_check', None)
+            db_session.commit()
+    return False
+
+
 def is_indexing():
-    timeout = current_app.config.get("INDEXING_TIMEOUT", 10 * 60)  # Default index timeout to 10 minutes (after which indexing will be permitted to run again)
+    timeout = current_app.config["INDEXING_TIMEOUT"]  # Default index timeout to 10 minutes (after which indexing will be permitted to run again)
     last_update = time_since_index()
     return IndexMetadata.get('lock', 'index', UNLOCKED) == LOCKED and last_update is not None and (last_update < timeout)
 
@@ -37,7 +91,7 @@ def time_since_index(human_readable=False):
 
 
 def time_since_index_check(human_readable=False):
-    last_update = IndexMetadata.get_last_update('check', 'index')
+    last_update = IndexMetadata.get_last_update('lock', 'index_master')
     if human_readable and last_update is None:
         return "Never"
     return time_since(last_update, human_readable=human_readable)
@@ -51,110 +105,100 @@ def get_indexed_revisions():
     return indexed
 
 
-def update_index_required(check_timeouts=True):
-    if not current_app.config.get('REPOSITORY_INDEXING_ENABLED', True):
+def index_due_for_update():
+    if not current_app.config['INDEXING_ENABLED']:
         return False
 
-    if is_indexing():
-        return False
-
-    interval = current_app.config.get("INDEXING_INTERVAL", 5 * 60)  # Default to 6 minutes between indexing tasks
+    interval = current_app.config["INDEXING_INTERVAL"]
     seconds = time_since_index()
     seconds_check = time_since_index_check()
 
-    if check_timeouts and (seconds is not None and seconds_check is not None) and (seconds < interval or seconds_check < interval):
+    if (seconds is not None and seconds_check is not None) and (seconds < interval or seconds_check < interval):
         return False
+
+    return True
+
+
+def index_up_to_date():
+    for uri, revision in current_repo.revisions.items():
+        indexed_revision = IndexMetadata.get('repository_revision', uri)
+        if indexed_revision is None or indexed_revision < str(revision):
+            return False
+    return True
+
+
+@ErrorLog.logged
+def update_index(check_timeouts=True, force=False, reindex=False):
+
+    if not current_app.config['INDEXING_ENABLED']:
+        return False
+
+    if check_timeouts and not index_due_for_update():
+        return False
+
+    is_index_master = acquire_index_lock()
+
+    # Check for update to repositories if configured to do so
+    if (
+        current_app.config['INDEXING_UPDATES_REPOSITORIES'] and
+        (is_index_master or current_app.config['INDEXING_UPDATES_REPOSITORIES_WITHOUT_LOCK'])
+    ):
+        current_repo.update()
+
+    # Short-circuit if not the index master (unless force is True)
+    if not is_index_master and not force or index_up_to_date():
+        return False
+
     try:
-        for uri, revision in current_repo.revisions.items():
-            indexed_revision = IndexMetadata.get('repository_revision', uri)
-            if indexed_revision is None or indexed_revision < str(revision):
-                return True
-        return False
-    finally:
-        IndexMetadata.set('check', 'index', CHECKED)
+        IndexMetadata.set('lock', 'index', LOCKED)
         db_session.commit()
 
+        kr_dir = {kp.path: kp for kp in current_repo.posts()}
+        kr_uuids = {kp.uuid: kp for kp in kr_dir.values()}
+        posts = db_session.query(Post).all()
 
-def update_index(check_timeouts=True):
-    """
-    Initialize the db from a KnowledgeRepository object
-    """
+        for post in posts:
 
-    if not update_index_required(check_timeouts=check_timeouts):
-        return
+            # If UUID has changed, check if we can find it elsewhere in the repository, and if so update index path
+            if post.uuid and ((post.path not in kr_dir) or (post.uuid != kr_dir[post.path].uuid)):
+                if post.uuid in kr_uuids:
+                    logger.info(u'Updating location of post: {} -> {}'.format(post.path, kr_uuids[post.uuid].path))
+                    post.path = kr_uuids[post.uuid].path
 
-    app = current_app._get_current_object()
-    index_db = current_app.config['SQLALCHEMY_DATABASE_URI']
+            # If path of post no longer in directory, mark as unpublished
+            if post.path not in kr_dir:
+                logger.info(u'Recording unpublished status for post at {}'.format(post.path))
+                post.status = current_repo.PostStatus.UNPUBLISHED
+                continue
 
-    if not index_db.startswith('sqlite://'):
-        t = threading.Thread(target=_update_index, args=(app,))
-        t.daemon = True
-        t.start()
-    else:
-        _update_index(current_app)
+            # Update database according to current state of existing knowledge post and
+            # remove from kp_dir. This means that when this loop finishes, kr_dir will
+            # only contain posts which are new to the repo.
+            kp = kr_dir.pop(post.path)
 
+            # Update metadata of post if required
+            if reindex or (kp.revision > post.revision or not post.is_published or kp.uuid != post.uuid):
+                if kp.is_valid():
+                    logger.info(u'Recording update to post at: {}'.format(kp.path))
+                    post.update_metadata_from_kp(kp)
+                else:
+                    logger.warning(u'Update to post at "{}" is corrupt.'.format(kp.path))
 
-def _update_index(app, force=False, reindex=False):
+        # Add the new posts that remain in kr_dir
+        for kp_path, kp in kr_dir.items():
+            if not kp.is_valid():
+                logger.warning(u'New post at "{}" is corrupt.'.format(kp.path))
+                continue
+            logger.info(u'creating new post from path {}'.format(kp_path))
+            post = Post()
+            db_session.add(post)
+            db_session.flush()  # (matthew) Fix groups logic so this is not necessary
+            post.update_metadata_from_kp(kp)
+            send_subscription_emails(post)
 
-    context = None
-    if not has_app_context():
-        context = app.app_context()
-        context.__enter__()
-
-    if not force and is_indexing():
-        return
-    IndexMetadata.set('lock', 'index', LOCKED)
-    db_session.commit()
-
-    kr_dir = {kp.path: kp for kp in current_repo.posts()}
-    kr_uuids = {kp.uuid: kp for kp in kr_dir.values()}
-    posts = db_session.query(Post).all()
-
-    for post in posts:
-
-        # If UUID has changed, check if we can find it elsewhere in the repository, and if so update index path
-        if post.uuid and ((post.path not in kr_dir) or (post.uuid != kr_dir[post.path].uuid)):
-            if post.uuid in kr_uuids:
-                logger.info(u'Updating location of post: {} -> {}'.format(post.path, kr_uuids[post.uuid].path))
-                post.path = kr_uuids[post.uuid].path
-
-        # If path of post no longer in directory, mark as unpublished
-        if post.path not in kr_dir:
-            logger.info(u'Recording unpublished status for post at {}'.format(post.path))
-            post.status = current_repo.PostStatus.UNPUBLISHED
-            continue
-
-        # Update database according to current state of existing knowledge post and
-        # remove from kp_dir. This means that when this loop finishes, kr_dir will
-        # only contain posts which are new to the repo.
-        kp = kr_dir.pop(post.path)
-
-        # Update metadata of post if required
-        if reindex or (kp.revision > post.revision or not post.is_published or kp.uuid != post.uuid):
-            if kp.is_valid():
-                logger.info(u'Recording update to post at: {}'.format(kp.path))
-                post.update_metadata_from_kp(kp)
-            else:
-                logger.warning(u'Update to post at "{}" is corrupt.'.format(kp.path))
-
-    # Add the new posts that remain in kr_dir
-    for kp_path, kp in kr_dir.items():
-        if not kp.is_valid():
-            logger.warning(u'New post at "{}" is corrupt.'.format(kp.path))
-            continue
-        logger.info(u'creating new post from path {}'.format(kp_path))
-        post = Post()
-        db_session.add(post)
-        db_session.flush()  # (matthew) Fix groups logic so this is not necessary
-        post.update_metadata_from_kp(kp)
-        send_subscription_emails(post)
-
-    # Record revision
-    for uri, revision in current_repo.revisions.items():
-        IndexMetadata.set('repository_revision', uri, str(revision))
-
-    IndexMetadata.set('lock', 'index', UNLOCKED)
-    db_session.commit()
-
-    if context is not None:
-        context.__exit__(None, None, None)
+        # Record revision
+        for uri, revision in current_repo.revisions.items():
+            IndexMetadata.set('repository_revision', uri, str(revision))
+    finally:
+        IndexMetadata.set('lock', 'index', UNLOCKED)
+        db_session.commit()

--- a/knowledge_repo/app/models.py
+++ b/knowledge_repo/app/models.py
@@ -141,6 +141,7 @@ class ErrorLog(db.Model):
             try:
                 return function(*args, **kwargs)
             except Exception as e:
+                db_session.rollback()
                 db_session.add(ErrorLog.from_exception(e))
                 db_session.commit()
                 raise_with_traceback(e)
@@ -172,7 +173,7 @@ class PageView(db.Model):
             return getattr(self._route, attr)
 
         def __call__(self, *args, **kwargs):
-            if not current_app.config.get('REPOSITORY_INDEXING_ENABLED', True):
+            if not current_app.config.get('INDEXING_ENABLED', True):
                 return self._route(*args, **kwargs)
 
             log = PageView(

--- a/knowledge_repo/app/routes/debug.py
+++ b/knowledge_repo/app/routes/debug.py
@@ -62,7 +62,7 @@ def show_versions():
 @blueprint.route('/debug/force_reindex', methods=['GET'])
 def force_reindex():
     reindex = bool(request.args.get('reindex', ''))
-    current_app.db_update_index(reindex=reindex)
+    current_app.db_update_index(check_timeouts=False, force=True, reindex=reindex)
     return "Index Updated"
 
 

--- a/knowledge_repo/app/routes/posts.py
+++ b/knowledge_repo/app/routes/posts.py
@@ -40,7 +40,7 @@ def render(path):
         # html = create_presentation_text(presentation_post)
         tmpl = "markdown-presentation.html"
 
-    if not current_app.config.get('REPOSITORY_INDEXING_ENABLED', True):
+    if not current_app.config.get('INDEXING_ENABLED', True):
         return _render_preview(path=path, tmpl=tmpl)
 
     post = (db_session.query(Post)

--- a/knowledge_repo/app/utils/time.py
+++ b/knowledge_repo/app/utils/time.py
@@ -1,9 +1,9 @@
 import datetime
 
 
-def time_since(dt, human_readable=False):
+def time_since(dt, human_readable=False, default=None):
     if dt is None:
-        return None
+        return default
     assert isinstance(dt, datetime.datetime)
     delta = (datetime.datetime.utcnow() - dt).total_seconds()
     if human_readable:

--- a/scripts/knowledge_repo
+++ b/scripts/knowledge_repo
@@ -271,7 +271,7 @@ if args.action in ['preview', 'runserver']:
                                   debug=args.debug,
                                   db_uri=args.dburi,
                                   config=args.config,
-                                  REPOSITORY_INDEXING_ENABLED=(args.action == 'runserver'))
+                                  INDEXING_ENABLED=(args.action == 'runserver'))
 
     if args.action == 'preview':
         kp_path = repo._kp_path(args.path)
@@ -312,4 +312,4 @@ elif args.action == 'db_migrate':
 
 elif args.action == 'reindex':
     app = repo.get_app(db_uri=args.dburi, debug=args.debug, config=args.config)
-    app.db_update_index(reindex=True)
+    app.db_update_index(check_timeouts=False, force=True, reindex=True)


### PR DESCRIPTION
... and making use of improved error logging.

This patch reworks how index synchronisation is done. Previously, every thread would attempt to trigger an update to the index (if needed) at request time. This patch changes this behaviour such that one instance/thread of the knowledge repo claims to be the index master, and remains so until it fails to update the index; whereupon this responsibility automatically shifts to a difference instance. This should greatly reduce the chance of lock collisions.

As a result of this improved logic, we can now update the knowledge repositories as part of the index update, for which initial support is added in this PR. This will likely be improved on the actual post storage side in the future, to enable, for example, tunnelled git operations for updating `GitKnowledgeRepository` instances. As such, this PR addresses and closes #295.

It also dumps errors in the synchronisation process into the errorlog, making it much easier to diagnose errors.

@jdavidheiser: Can you check that this works in your set up?

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
