### PR TITLE
Allow the knowledge_repo server to populate various user attributes (if desired)

### DIFF
--- a/knowledge_repo/app/app.py
+++ b/knowledge_repo/app/app.py
@@ -22,7 +22,7 @@ from .auth_provider import KnowledgeAuthProvider
 from .proxies import db_session, current_repo, current_user
 from .index import update_index, time_since_index, time_since_index_check, _update_index
 from .models import db as sqlalchemy_db, Post, User, Tag
-from .utils.auth import AnonymousKnowledgeUser, populate_identity_roles
+from .utils.auth import AnonymousKnowledgeUser, populate_identity_roles, prepare_user
 
 
 logging.basicConfig(level=logging.INFO)
@@ -101,8 +101,7 @@ class KnowledgeFlask(Flask):
                         identifier = current_app.config['AUTH_USER_IDENTIFIER_REQUEST_HEADER_MAPPING'](identifier)
                     user = User(identifier=identifier)
                     user.can_logout = False
-                    if user.id is None:
-                        db_session.commit()
+                    user = prepare_user(user, session_start=False)
                     return user
 
         # Intialise access policies

--- a/knowledge_repo/app/auth_provider.py
+++ b/knowledge_repo/app/auth_provider.py
@@ -5,11 +5,10 @@ from builtins import object
 
 from future.utils import with_metaclass
 from flask import request, redirect, current_app, session, Blueprint, url_for, session
-from flask_login import login_user, logout_user, login_required
-from flask_principal import identity_changed, Identity
 
 from .models import User
 from .proxies import db_session
+from .utils.auth import prepare_user
 from ..utils.registry import SubclassRegisteringABCMeta
 
 
@@ -60,8 +59,7 @@ class KnowledgeAuthProvider(with_metaclass(SubclassRegisteringABCMeta, object)):
         return True
 
     def _perform_login(self, user):
-        db_session.add(user)
-        db_session.commit()
+        user = prepare_user(user)
         login_user(user)
 
         # Notify flask principal that the identity has changed

--- a/knowledge_repo/app/config_defaults.py
+++ b/knowledge_repo/app/config_defaults.py
@@ -1,3 +1,4 @@
+import datetime
 # ---------------------------------------------------
 # Host configuration
 # ---------------------------------------------------
@@ -77,6 +78,28 @@ AUTH_USER_IDENTIFIER_REQUEST_HEADER = None
 def AUTH_USER_IDENTIFIER_REQUEST_HEADER_MAPPING(identifier):
     return identifier
 
+
+# If the server desires to modify the attributes of the `User` object associated with
+# users logged in via any of the above authentication providers, it can do so via
+# this configuration key. This function will be run once at user login (if using
+# an `AuthenticationProvider`, and then at most once during any caching lifetime
+# period (as specified below). Note that attributes collected via
+# `AuthenticationProvider`s will not be updated after initial login (user must
+# relogin in order to reset those attributes).
+def AUTH_USER_ATTRIBUTE_SETTER(user):
+    return user
+
+
+# The time to wait before re-checking user attributes with the above function
+# for users logged in via request headers.
+AUTH_USER_ATTRIBUTE_CACHE_LIFETIME = 24 * 60 * 60  # 1 day
+
+# Once a user is logged in via an authentication provider, they will remain
+# logged in via the use of cookies. By default, this cookie will last one year.
+# This is managed by `flask_login`, but is copied here for convenience.
+# For other options regarding sessions, please refer to:
+# https://flask-login.readthedocs.io/en/latest/#cookie-settings
+REMEMBER_COOKIE_DURATION = datetime.timedelta(days=365)
 
 # ---------------------------------------------------
 # Policy configuration

--- a/knowledge_repo/app/utils/auth.py
+++ b/knowledge_repo/app/utils/auth.py
@@ -1,11 +1,34 @@
+import datetime
+
 from future.moves.urllib.parse import urlparse, urlencode, urljoin
 
 from flask import request, url_for
-from flask_login import AnonymousUserMixin
-from flask_principal import UserNeed
+from flask_login import AnonymousUserMixin, login_user
+from flask_principal import Identity, identity_changed, UserNeed
 
 from .. import roles
-from ..proxies import current_app
+from ..proxies import current_app, db_session
+
+
+def prepare_user(user, session_start=True):
+    cache_lifetime = current_app.config['AUTH_USER_ATTRIBUTE_CACHE_LIFETIME'] or 0
+    if (
+        current_app.config['AUTH_USER_ATTRIBUTE_SETTER'] and
+        (
+            session_start or
+            user.last_login_at is None or
+            user.last_login_at < datetime.datetime.now() - datetime.timedelta(seconds=cache_lifetime)
+        )
+    ):
+        session_start = True
+        user = current_app.config['AUTH_USER_ATTRIBUTE_SETTER'](user)
+
+    if session_start or user.id is None:
+        user.last_login_at = datetime.datetime.now()
+        db_session.add(user)
+        db_session.commit()
+
+    return user
 
 
 class AnonymousKnowledgeUser(AnonymousUserMixin):


### PR DESCRIPTION
Currently, only `AuthProvider` instances can set user attributes. It is often necessary, however, for servers managing user authentication using request headers to assign user attributes also. This patch, has been tested locally, furnishes this functionality.

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
