### PR TITLE
R converter should not skip init files 

### DIFF
--- a/knowledge_repo/converters/rmd.py
+++ b/knowledge_repo/converters/rmd.py
@@ -18,7 +18,7 @@ class RmdConverter(KnowledgePostConverter):
             tmp_fd, tmp_path = tempfile.mkstemp()
             os.close(tmp_fd)
 
-            runcmd = """R --vanilla --slave -e "library(knitr); setwd('{0}'); \
+            runcmd = """R --no-save --no-restore --slave -e "library(knitr); setwd('{0}'); \
                         x = knit('{1}', '{2}', quiet=T)" """.format(os.path.abspath(os.path.dirname(filename)),
                                                                     os.path.abspath(filename),
                                                                     tmp_path)


### PR DESCRIPTION
Tested adding a Rmd file that required some init code found in Rprofile 

Addresses
https://github.com/airbnb/knowledge-repo/issues/334

@matthewwardrop 