### PR TITLE
Added optional --template parameter when creating knowledge post

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ for ipynb
 ```
 knowledge_repo --repo ./example_repo create ipynb example_post.ipynb
 ```
+
+using a custom template
+```
+knowledge_repo --repo ./example_repo create --template path/to/template.Rmd Rmd example_post.Rmd
+```
+
 4\. Edit the notebook file `example_post.ipynb` or `example_post.Rmd` as you normally would.
 
 
@@ -210,6 +216,12 @@ If the knowledge data repository is created at `knowledge_data_repo`, running
 knowledge_repo --repo knowledge_data_repo create md ~/Documents/my_first_knowledge_post.md
 ```
 will create a file, `~/Documents/my_first_knowledge_post.md`, the contents of which will be the boilerplate template of the knowledge post.
+
+You can also specify the location of a custom knowledge post template with the optional `--template` argument:
+
+```
+knowledge_repo --repo <repo_path> create --template path/to/template{.ipynb, .Rmd, .md} {ipynb, Rmd, md} filename
+```
 
 The help menu for this command (and all following commands) can be reached by adding the `-h` flag, `knowledge_repo --repo <repo_path> create -h`.
 

--- a/scripts/knowledge_repo
+++ b/scripts/knowledge_repo
@@ -126,6 +126,7 @@ init.add_argument('--tooling-branch', help='The branch to use when embedding the
 
 create = subparsers.add_parser('create', help='Start a new knowledge post based on a template.')
 create.set_defaults(action='create')
+create.add_argument('--template', default=None, help='The template to use when creating the knowledge post.')
 create.add_argument('format', choices=['ipynb', 'Rmd', 'md'], help='The format of the knowledge post to be created.')
 create.add_argument('filename', help='Where this file should be created.')
 #
@@ -230,6 +231,10 @@ repo = knowledge_repo.KnowledgeRepository.for_uri(args.repo)
 # Create a new knowledge post from a template
 if args.action == 'create':
     src = os.path.join(os.path.dirname(knowledge_repo.__file__), 'templates', 'knowledge_template.{}'.format(args.format))
+    if args.template:
+        src = args.template
+    if not os.path.exists(src):
+        raise ValueError("Template not found at {}. Please choose a different template and try again.".format(src))
     if os.path.exists(args.filename):
         raise ValueError("File already exists at '{}'. Please choose a different filename and try again.".format(args.filename))
     shutil.copy(src, args.filename)


### PR DESCRIPTION
Description of changeset: 

I added an optional `--template` parameter when creating a knowledge post. This allows users to specify their own template instead of using the prebuilt defaults, which can be verbose. I updated the documentation to reflect these changes.

Fixes #339 

Test Plan: 

There were no tests for CLI parsing in the current repo, but I confirmed that existing tests pass.


Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
