### PR TITLE
Remove catch-all exception handling when verifying posts

### DIFF
--- a/knowledge_repo/post.py
+++ b/knowledge_repo/post.py
@@ -338,7 +338,7 @@ class KnowledgePost(object):
             return False
         try:
             FormatChecks.process(self)
-        except:
+        except AssertionError:
             return False
         return True
 


### PR DESCRIPTION
Description of changeset: Stop silently suppressing all exceptions

Test Plan: Ran with mix of bystrings and unicodes and confirmed that the errors related to encoding.py actually fired as expected depending on what data was passed around.


Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
