### PR TITLE
update urlmapper to use string replacement for speed

### DIFF
--- a/knowledge_repo/converters/html.py
+++ b/knowledge_repo/converters/html.py
@@ -202,9 +202,7 @@ class HTMLConverter(KnowledgePostConverter):
             for urlmapper in urlmappers:
                 new_url = urlmapper(name, match.group('url'))
                 if new_url is not None:
-                    break
-            if new_url is not None:
-                return re.sub('(src|href)=[\'"](?:.*?)[\'"]', '\\1="{}"'.format(new_url), match.group(0))
+                    return match.group(0).replace(match.group('url'), new_url)
             return None
 
         return SubstitutionMapper(patterns=patterns, mappers=[urlmapper_proxy]).apply(html)


### PR DESCRIPTION
Addresses https://github.com/airbnb/knowledge-repo/issues/350

By using string replacement instead of regex substitution post rendering went from ~5 seconds to ~.1 seconds 

@matthewwardrop 