### PR TITLE
restrict typeahead search to only show published posts

### DIFF
--- a/knowledge_repo/app/routes/index.py
+++ b/knowledge_repo/app/routes/index.py
@@ -223,6 +223,7 @@ def ajax_post_typeahead():
     match_score = sum(case_statements).label("match_score")
 
     posts = (db_session.query(Post, match_score)
+                       .filter(Post.status == current_repo.PostStatus.PUBLISHED.value)
                        .order_by(desc(match_score))
                        .limit(5)
                        .all())


### PR DESCRIPTION
Currently the post search typeahead shows any posts, this change makes it so typeahead only shows published posts. 

@NiharikaRay @robjwang  