### PR TITLE
Add template for permission denied

### DIFF
--- a/knowledge_repo/app/app.py
+++ b/knowledge_repo/app/app.py
@@ -132,8 +132,7 @@ class KnowledgeFlask(Flask):
 
         @self.errorhandler(PermissionDenied)
         def handle_insufficient_permissions(error):
-            flash("You have insufficient permissions to access this resource.")
-            return render_template('base.html'), 403
+            return render_template('permission_denied.html'), 403
 
         # Add mail object if configuration is supplied
         if self.config.get('MAIL_SERVER'):

--- a/knowledge_repo/app/templates/permission_denied.html
+++ b/knowledge_repo/app/templates/permission_denied.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+
+{% block title %}
+Knowledge Repo 403
+{% endblock %}
+
+{% block content %}
+<div class="col-12">
+  <div class="panel">
+    <center>
+        <div class="panel-header">
+          Error!
+        </div>
+    </center>
+
+    <center>
+        <div class="panel-body">
+          <div class="row row-space-2"></div>
+          <h3> You don't have permission to view this page! </h3>
+          {% if current_user.is_authenticated %}
+          <text> If you think you should have access to this page, please contact a site admin. </text>
+          {% else %}
+          <text> <a href="{{ url_for('auth.login') }}">Click here</a> to sign in, and then try accessing this page again. </text>
+          {% endif %}
+        </div>
+    </center>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
Description of changeset: 
This PR creates a new template for use when a user attempts to view a page they are not authorized to see without logging in.  (Addresses #366) If the user is not signed in, they are prompted to sign in and try again.  If they are already signed in, it displays a less helpful "contact an admin" message.

Screenshot of new template:
<img width="1185" alt="permission denied template" src="https://user-images.githubusercontent.com/18429125/34576656-a0715f26-f14c-11e7-8463-360f8a2dbd71.png">


Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
