### PR TITLE
Enable generic OAuth2 config and support self-signed provider CAs

### DIFF
--- a/knowledge_repo/app/auth_providers/oauth2.py
+++ b/knowledge_repo/app/auth_providers/oauth2.py
@@ -77,7 +77,7 @@ class OAuth2Provider(KnowledgeAuthProvider):
              client_id=None,
              client_secret=None,
              user_info_mapping=None,
-             verify_https=None,
+             verify_ssl_certs=None,
              validate=None):
 
         (self.base_url,
@@ -89,7 +89,7 @@ class OAuth2Provider(KnowledgeAuthProvider):
          self.client_id,
          self.client_secret,
          self.user_info_mapping,
-         self.verify_https,
+         self.verify_ssl_certs,
          validate) = _resolve_oauth_config(
             self.name,
             locals(),
@@ -103,14 +103,14 @@ class OAuth2Provider(KnowledgeAuthProvider):
             'client_id',
             'client_secret',
             'user_info_mapping',
-            'verify_https',
+            'verify_ssl_certs',
             'validate'
         )
         if validate is not None:
             self.validate = lambda x: validate(self, x)
 
-        if self.verify_https is None:
-            self.verify_https = True
+        if self.verify_ssl_certs is None:
+            self.verify_ssl_certs = True
 
         redirect_url = self.app.config['SERVER_NAME'] or 'localhost:7000'
         if self.app.config['APPLICATION_ROOT']:
@@ -139,7 +139,7 @@ class OAuth2Provider(KnowledgeAuthProvider):
             self.token_url,
             client_secret=self.client_secret,
             code=request.args.get('code'),
-            verify=self.verify_https)
+            verify=self.verify_ssl_certs)
         return self.extract_user_from_api()
 
     def extract_user_from_api(self):
@@ -154,7 +154,7 @@ class OAuth2Provider(KnowledgeAuthProvider):
                 return d[key]
             raise RuntimeError("Invalid key type: {}.".format(key))
 
-        response = self.oauth_client.get(self.get_endpoint_url(self.user_info_endpoint), verify=self.verify_https)
+        response = self.oauth_client.get(self.get_endpoint_url(self.user_info_endpoint), verify=self.verify_ssl_certs)
         try:
             response_dict = json.loads(response.content)
             identifier = extract_from_dict(response_dict, self.user_info_mapping['identifier'])

--- a/knowledge_repo/app/auth_providers/oauth2.py
+++ b/knowledge_repo/app/auth_providers/oauth2.py
@@ -6,6 +6,7 @@ from ..auth_provider import KnowledgeAuthProvider
 
 
 PRESETS = {
+    'oauth2': {},  # allows generic OAuth2 to be configured in server_config.py
     'bitbucket': {
         'base_url': 'https://api.bitbucket.org/2.0/',
         'authorization_url': 'https://bitbucket.org/site/oauth2/authorize',

--- a/knowledge_repo/app/config_defaults.py
+++ b/knowledge_repo/app/config_defaults.py
@@ -51,7 +51,8 @@ DB_AUTO_UPGRADE = False
 # in a variety of different ways. You can create your own subclass of
 # `KnowledgeAuthProvider` and add either the instance or identifier
 # used for that class below.
-# By default, the knowledge repo offers: ['debug', 'bitbucket', 'github', 'google']
+# By default, the knowledge repo offers:
+# ['debug', 'oauth2', 'bitbucket', 'github', 'google']
 AUTH_PROVIDERS = []
 
 # If you are going to use a OAuth provider, you will need to specify client ids
@@ -59,7 +60,76 @@ AUTH_PROVIDERS = []
 # `OAuth2Provider` and adding them to the above list, or by specifying OAuth
 # connection properties as demonstrated below for the GitHub authenticator.
 # OAUTH_GITHUB_CLIENT_ID = '<client id>'
-# OAUTH_GITHUB_CLIENT_SECRET = '<client_secret>'
+# OAUTH_GITHUB_CLIENT_SECRET = '<client id>'
+
+# To configure a generic OAuth provider that is not one of the presets
+# provided, you may use the provider 'oauth2' which creates an empty,
+# unconfigured OAuth2Provider. You must then override its configuration.
+# For example, for a self-managed Gitlab CE instance at gitlab.example.com:
+
+# OAUTH_OAUTH2_BASE_URL = 'https://gitlab.example.com/api/v4/'
+# OAUTH_OAUTH2_AUTHORIZATION_URL = 'https://gitlab.example.com/oauth/authorize'
+# OAUTH_OAUTH2_TOKEN_URL = 'https://gitlab.example.com/oauth/token'
+# OAUTH_OAUTH2_AUTO_REFRESH_URL = 'https://gitlab.example.com/oauth/token'
+# OAUTH_OAUTH2_SCOPES = 'api'
+# OAUTH_OAUTH2_USER_INFO_ENDPOINT = 'user'
+# OAUTH_OAUTH2_USER_INFO_MAPPING = {
+#     'identifier': 'username',
+#     'name': 'name',
+#     'avatar_uri': 'avatar_url'
+# }
+# OAUTH_OAUTH2_VERIFY_HTTPS = '/path/to/certs/my.ca-bundle'
+# OAUTH_OAUTH2_CLIENT_ID = '<client id>'
+# OAUTH_OAUTH2_CLIENT_SECRET = '<client secret>'
+
+# The configuration OAUTH_<name>_VERIFY_HTTPS is what is passed to the
+# 'verify' parameter in the Requests module, and can be used to disable
+# HTTPS verification (not recommended) or provide a custom CA bundle. See:
+# http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification
+
+# You may also override the .validate() method of a KnowledgeAuthProvider
+# to perform an additional validation step before authenticating a user.
+# The following example checks whether a user has access to the git remote
+# of the local Knowledge Repository:
+
+# def OAUTH_OAUTH2_VALIDATE(provider, user):
+#
+#     if provider.app.repository.git_has_remote:
+#
+#         url_parts = (
+#             provider.app.repository.git_remote.url.split(':')
+#             )
+#
+#         url_subparts = url_parts[1].split('/')
+#
+#         if url_parts[0] == "git@gitlab.example.com":
+#             git_project = (
+#                 url_subparts[0] + "%2F" + url_subparts[1].split('.')[0])
+#         elif (
+#             url_parts[0] == "https"
+#             and url_subparts[2] == "gitlab.example.com"
+#         ):
+#             git_project = (
+#                 url_subparts[3] + "%2F" + url_subparts[4].split('.')[0])
+#         else:
+#             provider.app.logger.warning(
+#                 "User validation failed: unexpected git remote url ["
+#                 + provider.app.repository.git_remote.url + "]")
+#             return False
+#
+#         user_validate_url = provider.base_url + "projects/" + git_project
+#
+#         resp = provider.oauth_client.get(
+#             user_validate_url,
+#             verify=OAUTH_OAUTH2_VERIFY_HTTPS)
+#
+#         if resp.status_code == 200:
+#             return True
+#         else:
+#             provider.app.logger.warning(
+#                 "User validation failed: validation URL ["
+#                 + user_validate_url + "] returned HTTP status ["
+#                 + str(resp.status_code) + "]")
 
 # You can also forgo a fully-fledged sign in process for users
 # by hosting the knowledge repository behind a proxy server that

--- a/knowledge_repo/app/config_defaults.py
+++ b/knowledge_repo/app/config_defaults.py
@@ -60,7 +60,7 @@ AUTH_PROVIDERS = []
 # `OAuth2Provider` and adding them to the above list, or by specifying OAuth
 # connection properties as demonstrated below for the GitHub authenticator.
 # OAUTH_GITHUB_CLIENT_ID = '<client id>'
-# OAUTH_GITHUB_CLIENT_SECRET = '<client id>'
+# OAUTH_GITHUB_CLIENT_SECRET = '<client secret>'
 
 # To configure a generic OAuth provider that is not one of the presets
 # provided, you may use the provider 'oauth2' which creates an empty,
@@ -78,11 +78,11 @@ AUTH_PROVIDERS = []
 #     'name': 'name',
 #     'avatar_uri': 'avatar_url'
 # }
-# OAUTH_OAUTH2_VERIFY_HTTPS = '/path/to/certs/my.ca-bundle'
+# OAUTH_OAUTH2_VERIFY_SSL_CERTS = '/path/to/certs/my.ca-bundle'
 # OAUTH_OAUTH2_CLIENT_ID = '<client id>'
 # OAUTH_OAUTH2_CLIENT_SECRET = '<client secret>'
 
-# The configuration OAUTH_<name>_VERIFY_HTTPS is what is passed to the
+# The configuration OAUTH_<name>_VERIFY_SSL_CERTS is what is passed to the
 # 'verify' parameter in the Requests module, and can be used to disable
 # HTTPS verification (not recommended) or provide a custom CA bundle. See:
 # http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification

--- a/resources/server_config.py
+++ b/resources/server_config.py
@@ -1,6 +1,3 @@
-# This file is only needed for setting up a dedicated server configuration
-# with support for extracting username information and emailing users.
-
 import datetime
 # ---------------------------------------------------
 # Host configuration
@@ -54,7 +51,8 @@ DB_AUTO_UPGRADE = False
 # in a variety of different ways. You can create your own subclass of
 # `KnowledgeAuthProvider` and add either the instance or identifier
 # used for that class below.
-# By default, the knowledge repo offers: ['debug', 'bitbucket', 'github', 'google']
+# By default, the knowledge repo offers:
+# ['debug', 'oauth2', 'bitbucket', 'github', 'google']
 AUTH_PROVIDERS = []
 
 # If you are going to use a OAuth provider, you will need to specify client ids
@@ -62,7 +60,76 @@ AUTH_PROVIDERS = []
 # `OAuth2Provider` and adding them to the above list, or by specifying OAuth
 # connection properties as demonstrated below for the GitHub authenticator.
 # OAUTH_GITHUB_CLIENT_ID = '<client id>'
-# OAUTH_GITHUB_CLIENT_SECRET = '<client_secret>'
+# OAUTH_GITHUB_CLIENT_SECRET = '<client secret>'
+
+# To configure a generic OAuth provider that is not one of the presets
+# provided, you may use the provider 'oauth2' which creates an empty,
+# unconfigured OAuth2Provider. You must then override its configuration.
+# For example, for a self-managed Gitlab CE instance at gitlab.example.com:
+
+# OAUTH_OAUTH2_BASE_URL = 'https://gitlab.example.com/api/v4/'
+# OAUTH_OAUTH2_AUTHORIZATION_URL = 'https://gitlab.example.com/oauth/authorize'
+# OAUTH_OAUTH2_TOKEN_URL = 'https://gitlab.example.com/oauth/token'
+# OAUTH_OAUTH2_AUTO_REFRESH_URL = 'https://gitlab.example.com/oauth/token'
+# OAUTH_OAUTH2_SCOPES = 'api'
+# OAUTH_OAUTH2_USER_INFO_ENDPOINT = 'user'
+# OAUTH_OAUTH2_USER_INFO_MAPPING = {
+#     'identifier': 'username',
+#     'name': 'name',
+#     'avatar_uri': 'avatar_url'
+# }
+# OAUTH_OAUTH2_VERIFY_SSL_CERTS = '/path/to/certs/my.ca-bundle'
+# OAUTH_OAUTH2_CLIENT_ID = '<client id>'
+# OAUTH_OAUTH2_CLIENT_SECRET = '<client secret>'
+
+# The configuration OAUTH_<name>_VERIFY_SSL_CERTS is what is passed to the
+# 'verify' parameter in the Requests module, and can be used to disable
+# HTTPS verification (not recommended) or provide a custom CA bundle. See:
+# http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification
+
+# You may also override the .validate() method of a KnowledgeAuthProvider
+# to perform an additional validation step before authenticating a user.
+# The following example checks whether a user has access to the git remote
+# of the local Knowledge Repository:
+
+# def OAUTH_OAUTH2_VALIDATE(provider, user):
+#
+#     if provider.app.repository.git_has_remote:
+#
+#         url_parts = (
+#             provider.app.repository.git_remote.url.split(':')
+#             )
+#
+#         url_subparts = url_parts[1].split('/')
+#
+#         if url_parts[0] == "git@gitlab.example.com":
+#             git_project = (
+#                 url_subparts[0] + "%2F" + url_subparts[1].split('.')[0])
+#         elif (
+#             url_parts[0] == "https"
+#             and url_subparts[2] == "gitlab.example.com"
+#         ):
+#             git_project = (
+#                 url_subparts[3] + "%2F" + url_subparts[4].split('.')[0])
+#         else:
+#             provider.app.logger.warning(
+#                 "User validation failed: unexpected git remote url ["
+#                 + provider.app.repository.git_remote.url + "]")
+#             return False
+#
+#         user_validate_url = provider.base_url + "projects/" + git_project
+#
+#         resp = provider.oauth_client.get(
+#             user_validate_url,
+#             verify=OAUTH_OAUTH2_VERIFY_HTTPS)
+#
+#         if resp.status_code == 200:
+#             return True
+#         else:
+#             provider.app.logger.warning(
+#                 "User validation failed: validation URL ["
+#                 + user_validate_url + "] returned HTTP status ["
+#                 + str(resp.status_code) + "]")
 
 # You can also forgo a fully-fledged sign in process for users
 # by hosting the knowledge repository behind a proxy server that


### PR DESCRIPTION
The purpose of this PR is to simplify the process of supporting a generic OAuth2 authentication provider when deploying the software, and also to support self-signed CAs for those authentication providers.

Description of changeset: 

- Added a `verify_https` parameter to the `OAuth2Provider` class, whose only purpose is to be passed to the Requests module as the `verify` parameter. This is to support custom CAs (or disabling HTTPS verification entirely)
- Added a generic empty `OAuth2Provider` preset called `oauth2`, the purpose of which is to be overridden by the server administrator in server_config.py.
- Added examples of the use of both of these to `config_defaults.py`
- Synced `resources/server_config.py` with `config_defaults.py` as this is the config template referred to in the README.md, and looks out of date. (Perhaps a better solution is needed to keep these in sync long term.)

Functionality has been tested in production with a self-managed instance of GitLab CE.

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
