### PR TITLE
Change `preview` to `submit`

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -104,4 +104,4 @@ one way. For more workflows, refer to: :doc:`workflows/writing`.
 
   .. code-block:: shell
 
-    $ knowledge_repo --repo <path/uri_of_repo> preview <post_path_in_repository>
+    $ knowledge_repo --repo <path/uri_of_repo> submit <post_path_in_repository>


### PR DESCRIPTION
Description of changeset: 
In the example submission, I believe `knowledge_repo preview` is used when `knowledge_repo submit` is correct.

Test Plan: 


Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
