### PR TITLE
Remove unsafe tooling embedding, and replace with much safer method of pinning tooling version.

### DIFF
--- a/knowledge_repo/config_defaults.py
+++ b/knowledge_repo/config_defaults.py
@@ -108,6 +108,19 @@ def web_uri(repo, path=None):
 web_uri_base = None
 
 
+# If administrators of this knowledge repository want to suggest a specific
+# knowledge_repo version requirement when interacting with the repository using
+# the `knowledge_repo` script, they may do so here. Users can always work around
+# this restriction by using the `--dev` flag to the `knowledge_repo` script. If
+# the value supplied is a string starting with '!', it is taken to refer to a
+# git tag or commit hash on the upstream Knowledge Repo repository, and the
+# `knowledge_repo` script will clone the required  Knowledge Repo version and
+# chain commands to it. Otherwise, it is interpreted as a pip-like version
+# description (e.g. '==x.y.z', '>0.1.2<=0.8.0', etc), and the currently running
+# version of the `knowledge_repo` library is checked at runtime.
+required_tooling_version = None
+
+
 # WARNING: ADVANCED!
 # Function that is called on a Flask web app instance before it is launched
 # This is useful if you need to add a route for your local deployment, or other

--- a/knowledge_repo/config_defaults.yml
+++ b/knowledge_repo/config_defaults.yml
@@ -17,3 +17,5 @@ username_to_name_pattern: ['(?P<username>.*)', '{username}']
 username_to_email_pattern: ['(?P<username>.*)', '{username}@example.com']
 
 web_uri_base: ~
+
+required_tooling_version: ~

--- a/knowledge_repo/utils/git.py
+++ b/knowledge_repo/utils/git.py
@@ -1,0 +1,45 @@
+import errno
+import os
+import shutil
+import tempfile
+
+import git
+
+from knowledge_repo._version import __git_uri__
+
+
+def clone_kr_to_directory(dir):
+    dir = os.path.expanduser(dir)
+    if not os.path.exists(dir):
+        os.makedirs(dir)
+    assert os.path.isdir(dir)
+
+    try:
+        repo = git.Repo(dir)
+        repo.remote().fetch()
+    except git.InvalidGitRepositoryError:
+        repo = git.Repo.clone_from(__git_uri__, dir)
+
+
+def checkout_revision_to_dir(repo_path, revision, dir):
+    repo_path = os.path.expanduser(repo_path)
+    dir = os.path.expanduser(dir)
+    repo = git.Repo(repo_path)
+    repo.remote().fetch()
+    repo.git.checkout(revision)
+    return repo.git.checkout_index('-a', '-f', prefix=dir)
+
+
+class CheckedOutRevision(object):
+
+    def __init__(self, repo_path, revision):
+        self.repo_path = repo_path
+        self.revision = revision
+
+    def __enter__(self):
+        self.dir = tempfile.mkdtemp()
+        checkout_revision_to_dir(self.repo_path, self.revision, self.dir + '/')
+        return self.dir
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        shutil.rmtree(self.dir)

--- a/run_tests.bat
+++ b/run_tests.bat
@@ -19,21 +19,19 @@ REM Once we ship a public version, this should be changed to use the actual init
 SET test_repo_path=tests\test_repo
 
 REM Creating a test repository in %test_repo_path%...
-REM Remove the repository if it
+REM Remove the repository if it already exists
 IF EXIST "%test_repo_path%" (
   RMDIR /Q /S %test_repo_path%
 )
 
-# `dirname $0`/scripts/knowledge_repo --repo="${test_repo_path}" init # TODO: USE THIS AGAIN
-MKDIR %test_repo_path%
+%PYTHON%\\python.exe scripts/knowledge_repo --repo="${test_repo_path}" init
 COPY tests\config_repo.yml %test_repo_path%\.knowledge_repo_config.yml
 
 PUSHD %test_repo_path%
-  git init
   git config user.email "knowledge_developer@example.com"
   git config user.name "Knowledge Developer"
   git add .knowledge_repo_config.yml
-  git commit -m "Initial commit."
+  git commit -m "Update repository config."
 POPD
 
 # Add some knowledge_posts

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -24,16 +24,15 @@ echo "Creating a test repository in ${test_repo_path}..."
 # Remove the repository if it exists
 rm -rf ${test_repo_path} &> /dev/null
 
-# `dirname $0`/scripts/knowledge_repo --repo="${test_repo_path}" init # TODO: USE THIS AGAIN
+`dirname $0`/scripts/knowledge_repo --repo="${test_repo_path}" init
 mkdir -p ${test_repo_path} &> /dev/null
 cp `dirname $0`/tests/config_repo.yml ${test_repo_path}/.knowledge_repo_config.yml &> /dev/null
 
 pushd ${test_repo_path} &> /dev/null
-git init &> /dev/null
 git config user.email "knowledge_developer@example.com" &> /dev/null
 git config user.name "Knowledge Developer" &> /dev/null
 git add .knowledge_repo_config.yml &> /dev/null
-git commit -m "Initial commit." &> /dev/null
+git commit -m "Update repository config." &> /dev/null
 popd &> /dev/null
 
 # Add some knowledge_posts

--- a/scripts/knowledge_repo
+++ b/scripts/knowledge_repo
@@ -8,10 +8,12 @@ import itertools
 import signal
 import re
 import threading
-import webbrowser
 import shutil
 import argparse
 import subprocess
+
+import git
+import webbrowser
 from tabulate import tabulate
 
 # Register handler for SIGTERM, so we can run cleanup code if we are terminated
@@ -85,29 +87,55 @@ if args.repo is None:
     raise ValueError("No repository specified. Please set the --repo flag, "
                      "or the KNOWLEDGE_REPO environment variable.")
 
+# Load repository for use in subsequent commands. It may not be possible to load
+# the repository for various reasons, such as it not existing. At this point,
+# that is okay. Later on the requirement that te repository be correctly
+# initialised will be enforced.
+try:
+    repo = knowledge_repo.KnowledgeRepository.for_uri(args.repo)
+except (ValueError, git.InvalidGitRepositoryError):  # TODO: Generalise error to cater for all KnowledgeRepository instances.
+    repo = None
+
+
 # Update repository so that we can ensure git repository configuration is up to date
 # We wrap this in a try/except block because failing to update a repository can
 # happen for all sorts of reasons that should not inhibit other actions
 # For example: if the repository does not exist and the action will be 'init'
-if args.update:
-    try:
-        kr = knowledge_repo.KnowledgeRepository.for_uri(args.repo)
-        if isinstance(kr, GitKnowledgeRepository):
-            kr.update(branch=args.knowledge_branch)
-    except:
-        pass
+if repo is not None and args.update:
+    if isinstance(repo, GitKnowledgeRepository):
+        repo.update(branch=args.knowledge_branch)
+    else:
+        repo.update()
 
-# If not running in dev mode, and the specified repo exists, along with a knowledge_repo
+
+# If not running in dev mode, and the current knowledge repository requests that
+# a specific tooling version be used, this script checks whether it is suitable
+# for running the .. the specified repo exists, along with a knowledge_repo
 # script in the .resources/scripts folder, pass execution to this script in the
 # knowledge data repo. If this *is* that script, do nothing. This still allows the `init`
 # action to be run by this script in any case. Instances of this script in a data repo
 # are assumed to be in the: '.resources/scripts/knowledge_repo', and be part of a checked
 # out instance of the complete "knowledge-repo" repository.
-if (isinstance(args.repo, str) and not args.dev
-        and os.path.exists(os.path.join(args.repo, '.resources', 'scripts', 'knowledge_repo'))
-        and os.path.abspath(args.repo) != os.path.abspath(os.path.join(os.path.dirname(__file__), '../../'))):
-    cmdline_args = ['--noupdate'] + [arg.replace(' ', '\ ') if ' ' in arg else arg for arg in sys.argv[1:]]
-    sys.exit(subprocess.call('{} {}'.format(os.path.join(os.path.abspath(args.repo), '.resources/scripts/knowledge_repo'), ' '.join(cmdline_args)), shell=True))
+if repo is not None and not args.dev and repo.config.required_tooling_version:
+    required_version = repo.config.required_tooling_version
+    if required_version.startswith('!'):  # Specific revision requested
+        from knowledge_repo.utils.git import clone_kr_to_directory, CheckedOutRevision
+        clone_kr_to_directory('~/.knowledge_repo/git')
+        cmdline_args = ['--noupdate'] + [arg.replace(' ', '\ ') if ' ' in arg else arg for arg in sys.argv[1:]]
+        with CheckedOutRevision('~/.knowledge_repo/git', required_version[1:]) as script_path:
+            sys.exit(
+                subprocess.call(
+                    '{} {}'.format(os.path.join(script_path, 'scripts/knowledge_repo'), ' '.join(cmdline_args)
+                ), shell=True)
+            )
+    else:
+        from knowledge_repo.utils.dependencies import check_dependencies
+        check_dependencies([
+            'knowledge_repo{}{}'.format(
+                '==' if required_version[0] not in ['<', '=', '>'] else '',
+                required_version
+            )
+        ])
 
 # ---------------------------------------------------------------------------------------
 # Everything below this line pertains to actual actions to be performed on the repository
@@ -118,11 +146,8 @@ if (isinstance(args.repo, str) and not args.dev
 # Add the action parsers
 subparsers = parser.add_subparsers(help='sub-commands')
 
-init = subparsers.add_parser('init', help='Initialise a new git knowledge repository.')
+init = subparsers.add_parser('init', help='Initialise a new knowledge repository for the specified repository.')
 init.set_defaults(action='init')
-init.add_argument('--tooling-embed', action='store_true', help='Embed a reference version knowledge_repo tooling in the repository.')
-init.add_argument('--tooling-repo', help='The repository to use (if not the default).')
-init.add_argument('--tooling-branch', help='The branch to use when embedding the tools as a submodule (default is "master").')
 
 create = subparsers.add_parser('create', help='Start a new knowledge post based on a template.')
 create.set_defaults(action='create')
@@ -192,7 +217,7 @@ reindex.add_argument('-c', '--config', default=None, help="The config file from 
 
 # Show version and exit
 if args.version:
-    print('Embedded/active version: {}'.format(knowledge_repo.__version__))
+    print('Active version: {}'.format(knowledge_repo.__version__))
     sys.exit(0)
 
 # Only show db_migrate option if running in development mode, and in a git repository.
@@ -211,22 +236,18 @@ if not hasattr(args, 'action'):
 
 # If init, use this code to create a new repository.
 if args.action == 'init':
-    if args.tooling_embed:
-        embed_tooling = {}
-        if args.tooling_repo is not None:
-            embed_tooling['repository'] = args.tooling_repo
-        if args.tooling_branch is not None:
-            embed_tooling['branch'] = args.tooling_branch
+    assert not isinstance(args.repo, dict), "Only one repository can be initialised at a time."
+    repo = knowledge_repo.KnowledgeRepository.create_for_uri(args.repo)
+    if repo is not None:
+        print("Knowledge repository created for uri `{}`.".format(repo.uri))
     else:
-        embed_tooling = False
-    kr = knowledge_repo.KnowledgeRepository.create_for_uri(args.repo, embed_tooling=embed_tooling)
-    if kr is not None:
-        print("Knowledge repository created for uri `{}`.".format(kr.uri))
+        print("Something weird happened while creating repository for uri `{}`. Please report!".format(repo.uri))
     sys.exit(0)
 
-# All subsequent actions perform an action on the repository, and so we instantiate
-# a KnowledgeRepository object here.
-repo = knowledge_repo.KnowledgeRepository.for_uri(args.repo)
+# All subsequent actions perform an action on the repository, and so we verify
+# enforce that `repo` is not None.
+if repo is None:
+    raise RuntimeError("Could not initialise knowledge repository for uri `{}`. Please check the uri, and try again.".format(args.repo))
 
 # Create a new knowledge post from a template
 if args.action == 'create':


### PR DESCRIPTION
This is a follow up to #382 , which removed one method that a malicious user could use to cause arbitrary code to be run on client and server machines. This mitigates a second method, which was the running of arbitrary code within a git submodule in GitKnowledgeRepository instances when tooling was embedded.

This PR removes any dependence on git submodules, but retains the ability to pin `knowledge_repo` versions, since embedded tooling is still useful to help admins narrow the variance of user experiences (everyone will be using exactly the same `knowledge_repo` version). To cause arbitrary code to be run after this patch is merged, a malicious user would need to compromise network routing and perform a man-in-the-middle-attack, or hack this upstream repository, neither of which seems likely.

As per the configuration documentation:
```
# If administrators of this knowledge repository want to suggest a specific
# knowledge_repo version requirement when interacting with the repository using
# the `knowledge_repo` script, they may do so here. Users can always work around
# this restriction by using the `--dev` flag to the `knowledge_repo` script. If
# the value supplied is a string starting with '!', it is taken to refer to a
# git tag or commit hash on the upstream Knowledge Repo repository, and the
# `knowledge_repo` script will clone the required  Knowledge Repo version and
# chain commands to it. Otherwise, it is interpreted as a pip-like version
# description (e.g. '==x.y.z', '>0.1.2<=0.8.0', etc), and the currently running
# version of the `knowledge_repo` library is checked at runtime.
required_tooling_version = None
```

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
