### PR TITLE
Fix Windows build.

### DIFF
--- a/knowledge_repo/converters/rmd.py
+++ b/knowledge_repo/converters/rmd.py
@@ -18,10 +18,18 @@ class RmdConverter(KnowledgePostConverter):
             tmp_fd, tmp_path = tempfile.mkstemp()
             os.close(tmp_fd)
 
-            runcmd = """R --no-save --no-restore --slave -e "library(knitr); setwd('{0}'); \
-                        x = knit('{1}', '{2}', quiet=T)" """.format(os.path.abspath(os.path.dirname(filename)),
-                                                                    os.path.abspath(filename),
-                                                                    tmp_path)
+            runcmd = (
+                "Rscript --no-save --no-restore --slave -e \""
+                "library(knitr);"
+                "setwd('{wd}');"
+                "knit('{fname}', '{target_path}', quiet=F)"
+                "\""
+                .format(
+                    wd=os.path.abspath(os.path.dirname(filename)),
+                    fname=os.path.abspath(filename),
+                    target_path=tmp_path
+                )
+            )
 
             # Replace '\' with '\\' on Windows machines so R happy with filepath
             if os.name == 'nt':


### PR DESCRIPTION
The Windows build has been broken for a while. It looks like `R -e "..."` no longer supports spaces on Windows. We therefore use `Rscript` instead which is designed for this purpose, and works on all operating systems.

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
