### PR TITLE
Rewrote rmd.py converter to add plotly divs and js, and to add plotly…

### DIFF
--- a/knowledge_repo/converters/rmd.py
+++ b/knowledge_repo/converters/rmd.py
@@ -2,11 +2,27 @@ import os
 import logging
 import subprocess
 import tempfile
+import frontmatter
 
 from ..converter import KnowledgePostConverter
 
 
 logger = logging.getLogger(__name__)
+
+# Added to markdown if plotly.js is needed
+plotly_header = """<script>
+requirejs.config({paths: { 'plotly': ['https://cdn.plot.ly/plotly-latest.min']},});
+$(document).on('ready', function(){
+    var widget = $(".plotly.html-widget");
+    widget.each(function(){
+        var div = this,
+            json = JSON.parse(this.nextElementSibling.innerHTML),
+            data = json.x.data,
+            layout = json.x.layout;
+        require(["plotly"], function(Plotly) { Plotly.newPlot(div, data, layout);});
+    })
+});</script>
+"""
 
 
 class RmdConverter(KnowledgePostConverter):
@@ -18,28 +34,27 @@ class RmdConverter(KnowledgePostConverter):
             tmp_fd, tmp_path = tempfile.mkstemp()
             os.close(tmp_fd)
 
-            runcmd = (
-                "Rscript --no-save --no-restore --slave -e \""
-                "library(knitr);"
-                "setwd('{wd}');"
-                "knit('{fname}', '{target_path}', quiet=F)"
-                "\""
-                .format(
-                    wd=os.path.abspath(os.path.dirname(filename)),
-                    fname=os.path.abspath(filename),
-                    target_path=tmp_path
-                )
-            )
+            runcmd = """R --no-save --no-restore --slave -e " \
+                        library(rmarkdown); \
+                        render('{fname}', '{target_path}', \
+                        output_format = html_document(keep_md = T))"
+                        """.format(
+                            fname = os.path.abspath(filename),
+                            target_path = tmp_path
+                        )
 
             # Replace '\' with '\\' on Windows machines so R happy with filepath
             if os.name == 'nt':
                 runcmd = runcmd.replace("\\", "\\\\")
 
             subprocess.check_output(runcmd, shell=True)
-            Rmd_filename = tmp_path
+            Rmd_filename = tmp_path + ".md"
 
-        with open(Rmd_filename) as f:
-            self.kp.write(f.read())
+        post = frontmatter.load(Rmd_filename)
+        if "plotly" in post.content:
+            post.content = plotly_header + post.content
+
+        self.kp.write(frontmatter.dumps(post))
         self.kp.add_srcfile(filename)
 
         # Clean up temporary file

--- a/knowledge_repo/converters/rmd.py
+++ b/knowledge_repo/converters/rmd.py
@@ -2,7 +2,6 @@ import os
 import logging
 import subprocess
 import tempfile
-import frontmatter
 
 from ..converter import KnowledgePostConverter
 

--- a/knowledge_repo/converters/rmd.py
+++ b/knowledge_repo/converters/rmd.py
@@ -50,11 +50,23 @@ class RmdConverter(KnowledgePostConverter):
             subprocess.check_output(runcmd, shell=True)
             Rmd_filename = tmp_path + ".md"
 
-        post = frontmatter.load(Rmd_filename)
-        if "plotly" in post.content:
-            post.content = plotly_header + post.content
+        # Split file header from footer
+        with open(Rmd_filename) as f:
+            header = body = ""
+            delim_num = 0
+            for line in f.readlines():
+                if delim_num < 2:
+                    header += line
+                else:
+                    body += line
+                if line.strip() == "---":
+                    delim_num += 1
 
-        self.kp.write(frontmatter.dumps(post))
+        # If notebook needs plotly, add plotly.js lib
+        if "plotly" in body:
+            body = plotly_header + body
+
+        self.kp.write(header + body)
         self.kp.add_srcfile(filename)
 
         # Clean up temporary file

--- a/tests/test_posts/plotly.Rmd
+++ b/tests/test_posts/plotly.Rmd
@@ -1,0 +1,59 @@
+---
+title: Example post with plotly
+authors: [plotly_dude]
+tags:
+- knowledge
+- example
+created_at: 2016-06-29
+updated_at: 2016-06-30
+tldr: This is an example of using plotly
+path: test_post
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+```
+
+## R Markdown
+
+This is an R Markdown document. Markdown is a simple formatting syntax for authoring HTML, PDF, and MS Word documents. For more details on using R Markdown see <http://rmarkdown.rstudio.com>.
+
+When you click the **Knit** button a document will be generated that includes both content as well as the output of any embedded R code chunks within the document. You can embed an R code chunk like this:
+
+## Including Plots
+
+Here we're going to test some different plotly plots:
+
+```{r message=FALSE, warning=FALSE}
+library(plotly)
+data("diamonds")
+
+d <- diamonds[sample(nrow(diamonds), 1000), ]
+
+plot_ly(
+  d, x = ~carat, y = ~price,
+  color = ~carat, size = ~carat
+)
+```
+
+## Another plot
+
+```{r message=FALSE, warning=FALSE}
+data("volcano")
+
+plot_ly(z = volcano, type = "heatmap")
+```
+
+## 3D plot
+
+```{r message=FALSE, warning=FALSE}
+data <- read.csv('https://raw.githubusercontent.com/plotly/datasets/master/_3d-line-plot.csv')
+
+plot_ly(data, x = ~x1, y = ~y1, z = ~z1, type = 'scatter3d', mode = 'lines',
+        line = list(color = '#1f77b4', width = 1)) %>%
+  add_trace(x = ~x2, y = ~y2, z = ~z2,
+            line = list(color = 'rgb(44, 160, 44)', width = 1)) %>%
+  add_trace(x = ~x3, y = ~y3, z = ~z3,
+            line = list(color = 'bcbd22', width = 1))
+```
+


### PR DESCRIPTION
….js dependency

Description of changeset: 

In order to handle plotly plots, we use the rmarkdown::render function, which is a bit more capable than knitr. We render the Rmd to html format, with the option to keep the intermediate .md file. This is almost the same as the knitr output, but contains divs and a json description of the plots.

Additionally some javascript is necessary to have the actual plots rendered. I have a somewhat lazy check for whether we need to add the dependency. This could be improved on by check each code block for either `library(plotly)` or `plotly::`.

I also introduced a new dependency (`python-frontmatter`) to add the javascript tags after the frontmatter. There might be another way of doing this where this additional package isn't needed.

Test Plan: 
A new post is included with three different plotly plots.

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
