### PR TITLE
Allow to customize comments display

### DIFF
--- a/knowledge_repo/app/routes/posts.py
+++ b/knowledge_repo/app/routes/posts.py
@@ -72,7 +72,7 @@ def render(path):
     for comment in comments:
         author = db_session.query(User).filter(User.id == comment.user_id).first()
         if author is not None:
-            comment.author = author.identifier
+            comment.author = author.format_name
         else:
             comment.author = 'Anonymous'
         if mode != 'raw':


### PR DESCRIPTION
Description of changeset: 
This allows to change how the comment author name is displayed.
Currently, when logging in with Google, the comment author is displayed as the email address.
I would like to display the name of the commenter instead of his email address.
Here is a screenshot of the output.
![screenshot-2018-5-1 factiva api](https://user-images.githubusercontent.com/1436271/39467705-677fa356-4d6a-11e8-9591-fad4b9a8f8dc.png)
 
Test Plan: 
I am not sure how/if the comment list is tested. 
Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
