### PR TITLE
LDAP Auth blueprint

### DIFF
--- a/knowledge_repo/app/auth_providers/ldap.py
+++ b/knowledge_repo/app/auth_providers/ldap.py
@@ -1,4 +1,3 @@
-
 from flask import request, render_template
 from ldap3 import Server, Connection, ALL
 
@@ -10,20 +9,18 @@ class LdapAuthProvider(KnowledgeAuthProvider):
     _registry_keys = ['ldap']
 
     def init(self):
-        # Create server connection
-        address = "ldap://127.0.0.1:389" # Move to Config file
-        self.server = Server(address, get_info=ALL)
+        self.server = Server(self.app.config['LDAP_SERVER'], get_info=ALL)
 
     def prompt(self):
         return render_template('auth-login-form.html', skip_password=False)
 
     def validate(self, user):
-        user_id = user.identifier
+        userdn = self.app.config['USERDN_SCHEMA'].format(user.identifier)
         password = request.form['password']
-        userdn_string = "cn={0},ou=people,dc=planetexpress,dc=com"  # Move to Config file
-        conn = Connection(self.server, user=userdn_string.format(user_id), password=password)
+
+        conn = Connection(self.server, user=userdn, password=password)
         return conn.bind()
 
-    # TODO: Populate user with LDAP INFO. Put LDAP Schema in config file?
+    # TODO: Populate User object with LDAP information. Put LDAP Schema in config file?
     def get_user(self):
         return User(identifier=request.form['username'])

--- a/knowledge_repo/app/auth_providers/ldap.py
+++ b/knowledge_repo/app/auth_providers/ldap.py
@@ -1,0 +1,29 @@
+
+from flask import request, render_template
+from ldap3 import Server, Connection, ALL
+
+from ..models import User
+from ..auth_provider import KnowledgeAuthProvider
+
+
+class LdapAuthProvider(KnowledgeAuthProvider):
+    _registry_keys = ['ldap']
+
+    def init(self):
+        # Create server connection
+        address = "ldap://127.0.0.1:389" # Move to Config file
+        self.server = Server(address, get_info=ALL)
+
+    def prompt(self):
+        return render_template('auth-login-form.html', skip_password=False)
+
+    def validate(self, user):
+        user_id = user.identifier
+        password = request.form['password']
+        userdn_string = "cn={0},ou=people,dc=planetexpress,dc=com"  # Move to Config file
+        conn = Connection(self.server, user=userdn_string.format(user_id), password=password)
+        return conn.bind()
+
+    # TODO: Populate user with LDAP INFO. Put LDAP Schema in config file?
+    def get_user(self):
+        return User(identifier=request.form['username'])

--- a/knowledge_repo/app/config_defaults.py
+++ b/knowledge_repo/app/config_defaults.py
@@ -172,6 +172,18 @@ AUTH_USER_ATTRIBUTE_CACHE_LIFETIME = 24 * 60 * 60  # 1 day
 REMEMBER_COOKIE_DURATION = datetime.timedelta(days=365)
 
 # ---------------------------------------------------
+# LDAP configuration
+# ---------------------------------------------------
+# When using an LDAP server for user verification, you need to configure
+# the location of the server, and the directory structure used by your
+# organization.
+
+# Currently the port and protocol must both be included in the server address
+LDAP_SERVER = 'ldaps://127.0.0.1:389'
+# When entering this, note the "{0}" which denotes where the user_id is inserted.
+USERDN_SCHEMA = 'cn={0},ou=people,dc=planetexpress,dc=com'
+
+# ---------------------------------------------------
 # Policy configuration
 # ---------------------------------------------------
 # This section configures various policy related to access control.

--- a/knowledge_repo/app/templates/auth-login-form.html
+++ b/knowledge_repo/app/templates/auth-login-form.html
@@ -6,7 +6,8 @@
 .login-form {
     display: block;
     list-style-type: none;
-    margin: 10px;
+    width: 340px;
+    margin: 50px auto;
     padding: 1em;
     background: #fff;
     border: 1px solid #aaa;
@@ -27,12 +28,17 @@
 .login-form > input[type=submit] {
     margin-bottom: 0px;
 }
+.login-form > p {
+    font-size: 30px;
+    text-align: center;
+}
 </style>
 
 <form name='login' action='authorize' method='POST' class='login-form'>
+<p> Log in </p>
 <input type='text' placeholder="Username" name='username' />
 {% if not skip_password %}
-<input type='password' placeholder="Password" name='password' />
+<input type='password' placeholder="Password" name='password' required/>
 {% endif %}
 <input type='submit' value='Sign in'/>
 </form>

--- a/knowledge_repo/converters/rmd.py
+++ b/knowledge_repo/converters/rmd.py
@@ -2,11 +2,27 @@ import os
 import logging
 import subprocess
 import tempfile
+import frontmatter
 
 from ..converter import KnowledgePostConverter
 
 
 logger = logging.getLogger(__name__)
+
+# Added to markdown if plotly.js is needed
+plotly_header = """<script>
+requirejs.config({paths: { 'plotly': ['https://cdn.plot.ly/plotly-latest.min']},});
+$(document).on('ready', function(){
+    var widget = $(".plotly.html-widget");
+    widget.each(function(){
+        var div = this,
+            json = JSON.parse(this.nextElementSibling.innerHTML),
+            data = json.x.data,
+            layout = json.x.layout;
+        require(["plotly"], function(Plotly) { Plotly.newPlot(div, data, layout);});
+    })
+});</script>
+"""
 
 
 class RmdConverter(KnowledgePostConverter):
@@ -18,28 +34,27 @@ class RmdConverter(KnowledgePostConverter):
             tmp_fd, tmp_path = tempfile.mkstemp()
             os.close(tmp_fd)
 
-            runcmd = (
-                "Rscript --no-save --no-restore --slave -e \""
-                "library(knitr);"
-                "setwd('{wd}');"
-                "knit('{fname}', '{target_path}', quiet=F)"
-                "\""
-                .format(
-                    wd=os.path.abspath(os.path.dirname(filename)),
-                    fname=os.path.abspath(filename),
-                    target_path=tmp_path
-                )
-            )
+            runcmd = """R --no-save --no-restore --slave -e " \
+                        library(rmarkdown); \
+                        render('{fname}', '{target_path}', \
+                        output_format = html_document(keep_md = T))"
+                        """.format(
+                            fname = os.path.abspath(filename),
+                            target_path = tmp_path
+                        )
 
             # Replace '\' with '\\' on Windows machines so R happy with filepath
             if os.name == 'nt':
                 runcmd = runcmd.replace("\\", "\\\\")
 
             subprocess.check_output(runcmd, shell=True)
-            Rmd_filename = tmp_path
+            Rmd_filename = tmp_path + ".md"
 
-        with open(Rmd_filename) as f:
-            self.kp.write(f.read())
+        post = frontmatter.load(Rmd_filename)
+        if "plotly" in post.content:
+            post.content = plotly_header + post.content
+
+        self.kp.write(frontmatter.dumps(post))
         self.kp.add_srcfile(filename)
 
         # Clean up temporary file

--- a/tests/test_posts/plotly.Rmd
+++ b/tests/test_posts/plotly.Rmd
@@ -1,0 +1,59 @@
+---
+title: Example post with plotly
+authors: [plotly_dude]
+tags:
+- knowledge
+- example
+created_at: 2016-06-29
+updated_at: 2016-06-30
+tldr: This is an example of using plotly
+path: test_post
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+```
+
+## R Markdown
+
+This is an R Markdown document. Markdown is a simple formatting syntax for authoring HTML, PDF, and MS Word documents. For more details on using R Markdown see <http://rmarkdown.rstudio.com>.
+
+When you click the **Knit** button a document will be generated that includes both content as well as the output of any embedded R code chunks within the document. You can embed an R code chunk like this:
+
+## Including Plots
+
+Here we're going to test some different plotly plots:
+
+```{r message=FALSE, warning=FALSE}
+library(plotly)
+data("diamonds")
+
+d <- diamonds[sample(nrow(diamonds), 1000), ]
+
+plot_ly(
+  d, x = ~carat, y = ~price,
+  color = ~carat, size = ~carat
+)
+```
+
+## Another plot
+
+```{r message=FALSE, warning=FALSE}
+data("volcano")
+
+plot_ly(z = volcano, type = "heatmap")
+```
+
+## 3D plot
+
+```{r message=FALSE, warning=FALSE}
+data <- read.csv('https://raw.githubusercontent.com/plotly/datasets/master/_3d-line-plot.csv')
+
+plot_ly(data, x = ~x1, y = ~y1, z = ~z1, type = 'scatter3d', mode = 'lines',
+        line = list(color = '#1f77b4', width = 1)) %>%
+  add_trace(x = ~x2, y = ~y2, z = ~z2,
+            line = list(color = 'rgb(44, 160, 44)', width = 1)) %>%
+  add_trace(x = ~x3, y = ~y3, z = ~z3,
+            line = list(color = 'bcbd22', width = 1))
+```
+


### PR DESCRIPTION
Description of changeset: 
Implements a simple auth blueprint for LDAP user verification. Currently uses username entered into the HTML from as the uid/cn for verification. I'm only familiar with how my organization has implemented this, but others can implement they want.

Test Plan: 
I tested this using [this LDAP docker image](https://github.com/rroemhild/docker-test-openldap), but it would take some work to add this to the travis/appveyor tests. Any ideas on this?

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
