### PR TITLE
Adding a meta tag for Knowledge Repo mobile layout changes

### DIFF
--- a/knowledge_repo/app/templates/base.html
+++ b/knowledge_repo/app/templates/base.html
@@ -23,6 +23,9 @@
     <script src="{{ url_for('static', filename='modules/require.js/require.min.js')}}"></script>
     <script src="{{ url_for('static', filename='js/pages/base.js')}}"></script>
 
+    <!-- Set explicit mobile collapse behaviour -->
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+
     <!-- fix for IE compatability mode -->
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <!--[if lt IE 9]>


### PR DESCRIPTION
Description of changeset: 

Super simple PR to add a meta tag to the base template to make KR play nice with mobile esp Android devices:

## Before:
### Feed
![2018-05-27 13 07 38](https://user-images.githubusercontent.com/8920001/40585743-93527842-61af-11e8-92fa-305ba2e05c4e.jpg)
### Post
![2018-05-27 13 07 52](https://user-images.githubusercontent.com/8920001/40585744-963ef882-61af-11e8-8103-ff6150635d58.jpg)

## After:
### Feed
![2018-05-27 13 07 05](https://user-images.githubusercontent.com/8920001/40585752-b1b45350-61af-11e8-9a68-724539f71935.jpg)
### Post
![2018-05-27 13 06 59](https://user-images.githubusercontent.com/8920001/40585753-b769ae94-61af-11e8-8fe9-9b8a5de1003f.jpg)


Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
