### PR TITLE
Nested folder structure for cluster view

### DIFF
--- a/knowledge_repo/app/routes/index.py
+++ b/knowledge_repo/app/routes/index.py
@@ -229,15 +229,18 @@ def render_cluster():
         clusters = [c for c in content if not c.is_post]
         posts = [c for c in content if c.is_post]
         if sort_by == "alpha":
-            content = (
+            sorted_content = (
                 sorted(clusters, key=lambda x: x.name) +
                 sorted(posts, key=lambda x: x.name)
             )
         else:
-            content = (
+            sorted_content = (
                 sorted(clusters, key=lambda x: x.children_count, reverse=sort_desc) +
                 sorted(posts, key=lambda x: x.children_count, reverse=sort_desc)
             )
+        # namedtuple is an immutable type, so we modify in place
+        content.clear()
+        content.extend(sorted_content)
 
     rec_sort(grouped_data, sort_by)
 

--- a/knowledge_repo/app/routes/index.py
+++ b/knowledge_repo/app/routes/index.py
@@ -239,7 +239,7 @@ def render_cluster():
                 sorted(posts, key=lambda x: x.children_count, reverse=sort_desc)
             )
         # namedtuple is an immutable type, so we modify in place
-        content.clear()
+        del content[:]
         content.extend(sorted_content)
 
     rec_sort(grouped_data, sort_by)

--- a/knowledge_repo/app/routes/index.py
+++ b/knowledge_repo/app/routes/index.py
@@ -191,7 +191,7 @@ def render_cluster():
                     children.append([k, False, l, contents])
                 else:
                     count += 1
-                    children.append([k, True, 1, v])
+                    children.append([k, True, 0, v])
             return count, children
 
         _, tuples = unpack(folder_to_posts)

--- a/knowledge_repo/app/static/css/pages/base.css
+++ b/knowledge_repo/app/static/css/pages/base.css
@@ -712,7 +712,8 @@ border-color: #11b6aa;
   margin-top: 0px;
   margin-right: -15px;
   margin-left: -15px;
-  padding-top: 10px
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 
 .cluster-dropdown {

--- a/knowledge_repo/app/static/js/index-cluster.js
+++ b/knowledge_repo/app/static/js/index-cluster.js
@@ -1,23 +1,11 @@
 var indexClusterJx = (function(){
 
   function addFoldingToGroups() {
-    var clusterList = $("#cluster_list").children();
-    $.each(clusterList, function(i, child) {
-      var tagName = child.tagName;
-      if (tagName === "LI") {
-        // this is the sublist toggle thing
-        var id = child.children[0].id;
-        var key_id = "#" + id.replace(/[^a-z0-9\s_]/gi, '');
-        var sublist = $(key_id + "-content");
-        var knowledgePosts = sublist.find("li");
-        if (id !== "" && knowledgePosts.length > 0) {
-          $(key_id).on("click", function() {
-            var icon = $(this).find("h6 > i");
-            $(icon).toggleClass("glyphicon-chevron-right glyphicon-chevron-down");
-            $(sublist).toggle("fold");
-          });
-        }
-      }
+    $('.cluster_dir').click(function(e) {
+      e.stopPropagation();
+      var icon = $(this).find("#" + this.id + "-glyph");
+      $(icon).toggleClass("glyphicon-chevron-right glyphicon-chevron-down");
+      $(this).siblings("#" + this.id + "-content").toggle("fold");
     });
   }
 

--- a/knowledge_repo/app/templates/index-cluster.html
+++ b/knowledge_repo/app/templates/index-cluster.html
@@ -47,29 +47,32 @@
     </div>
   </div>
   <ul id="cluster_list">
-  {% for cluster, contents in grouped_data %}
-    {%- if contents|length > 0 and cluster|length > 0 %}
-    {% set cluster_id = cluster|replace('/', '__')|replace(' ', '__')|replace('-', '__') %}
-    <li>
-    <div id="{{ cluster_id|safe }}">
-      <h6 style="margin-bottom:0"> {{ [cluster,' (', contents|length, ')'] | join }}
-        <i class="glyphicon glyphicon-chevron-right cluster-dropdown"></i>
-      </h6>
-    </div>
-    </li>
-      <div id="{{ cluster_id|safe }}-content" style="display:none">
-        <ul>
-        {% for item in contents %}
-          <li>
-            <a href="{{'/post/' + item.path|urlencode }}">
-              {{ item.title|replace('_', ' ')|title }}
-            </a>
-          </li>
-        {% endfor %}
-        </ul>
-     </div>
-    {%- endif%}
-  {% endfor %}
+  {%- for cluster, is_post, count, contents in grouped_data recursive %}
+    {%- if is_post %}
+      <li class="cluster_post" style="list-style-type:circle">
+        <a href="{{'/post/' + contents.path|urlencode }}">
+          {{ contents.title|replace('_', ' '|title )}}
+        </a>
+      </li>
+    {%- else %}
+      {%- if contents|length > 0 and cluster|length > 0 %}
+      {% set cluster_id = cluster|replace(' ', '__')|replace('-', '__') %}
+        <li id="{{ cluster_id|safe }}" class="cluster_dir" style="list-style-type:disc">
+          <div>
+            <h6 style="margin-bottom:0;margin-top:0">
+              {{ [cluster,' (', count, ')'] | join }}
+              <i id="{{ cluster_id|safe }}-glyph" class="glyphicon glyphicon-chevron-right cluster-dropdown"></i>
+            </h6>
+          </div>
+        </li>
+        <div id="{{ cluster_id|safe }}-content" style="display:none">
+          <ul>
+            {{ loop(contents) }}
+          </ul>
+        </div>
+      {%- endif %}
+    {%- endif %}
+  {%- endfor %}
   </ul>
 
 {% endblock %}

--- a/knowledge_repo/app/templates/index-cluster.html
+++ b/knowledge_repo/app/templates/index-cluster.html
@@ -66,7 +66,7 @@
           </div>
         </li>
         <div id="{{ cluster_id|safe }}-content" style="display:none">
-          <ul>
+          <ul style="margin-top: 0px">
             {{ loop(contents) }}
           </ul>
         </div>


### PR DESCRIPTION
Description of changeset: 

This PR adds a nested structure to the /cluster view, allowing for more compact categorization of posts. It is intended to resolve issue #170 

Sample screenshot:

![image](https://user-images.githubusercontent.com/15220906/40669917-f2e9cb64-635f-11e8-8f1a-890c156b4ef4.png)


Very happy to take suggestions on how to properly test this. Also feedback on the javascript changes are particularly welcome as I'm a bit of a novice.

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
