### PR TITLE
[gunicorn] Adding statsD options

### DIFF
--- a/knowledge_repo/app/deploy/common.py
+++ b/knowledge_repo/app/deploy/common.py
@@ -22,13 +22,17 @@ class KnowledgeDeployer(with_metaclass(SubclassRegisteringABCMeta, object)):
                  host='0.0.0.0',
                  port=7000,
                  workers=4,
-                 timeout=60):
+                 timeout=60,
+                 statsd_host=None,
+                 statsd_prefix=None):
         assert isinstance(knowledge_builder, (str, types.FunctionType)), u"Unknown builder type {}".format(type(knowledge_builder))
         self.knowledge_builder = knowledge_builder
         self.host = host
         self.port = port
         self.workers = workers
         self.timeout = timeout
+        self.statsd_host = statsd_host
+        self.statsd_prefix = statsd_prefix
 
     @classmethod
     def using(cls, engine):

--- a/knowledge_repo/app/deploy/gunicorn.py
+++ b/knowledge_repo/app/deploy/gunicorn.py
@@ -24,7 +24,9 @@ class GunicornDeployer(BaseApplication, KnowledgeDeployer):
         options = {
             'bind': u'{}:{}'.format(self.host, self.port),
             'workers': self.workers,
-            'timeout': self.timeout
+            'timeout': self.timeout,
+            'statsd_host': self.statsd_host,
+            'statsd_prefix': self.statsd_prefix,
         }
         for key, value in options.items():
             self.cfg.set(key, value)

--- a/scripts/knowledge_repo
+++ b/scripts/knowledge_repo
@@ -200,6 +200,8 @@ deploy.set_defaults(action='deploy')
 deploy.add_argument('-p', '--port', default=7000, type=int, help="Specify the port on which to run the web server")
 deploy.add_argument('-w', '--workers', default=4, type=int, help="Number of gunicorn worker threads to spin up.")
 deploy.add_argument('-t', '--timeout', default=60, type=int, help="Specify the timeout (seconds) for the gunicorn web server")
+deploy.add_argument('-sh', '--statsd-host', dest='statsd_host', default=None, type=str, help="The gunicorn statsD host")
+deploy.add_argument('-sp', '--statsd-prefix', dest='statsd_prefix', default=None, type=str, help="The gunicorn statsD prefix")
 deploy.add_argument('-db', '--dburi', help='The SQLAlchemy database uri.')
 deploy.add_argument('-c', '--config', default=None, help="The config file from which to read server configuration.")
 deploy.add_argument('--engine', default='gunicorn', help='Which server engine to use when deploying; choose from: "flask", "gunicorn" (default) or "uwsgi".')
@@ -331,7 +333,9 @@ elif args.action == 'deploy':
         host='0.0.0.0',
         port=args.port,
         workers=args.workers,
-        timeout=args.timeout
+        timeout=args.timeout,
+        statsd_host=args.statsd_host,
+        statsd_prefix=args.statsd_prefix,
     )
     server.run()
 


### PR DESCRIPTION
Description of changeset: 

This PR enables instrumentation to the Gunicorn webserver via the statsD protocol which is configurable via the [statsd_host](http://docs.gunicorn.org/en/stable/settings.html#statsd-host) and [statsd_prefix](http://docs.gunicorn.org/en/stable/settings.html#statsd-prefix) settings.

Note ideally it would  be great to have a mechanism of parsing arbitrary Gunicorn command line arguments which don't need to be individually registered or use a Gunicorn config file for configuring the Gunicorn webserver.

Test Plan: 

Verified that 
```
knowledge_repo deploy
knowledge_repo deploy --statsd-host=localhost:8125
knowledge_repo deploy --statsd-host=localhost:8125 --statsd-prefix=knowledge
```
correctly launched the Gunicorn webserver without error. 

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
