### PR TITLE
[gunicorn] Adding environment configuration

### DIFF
--- a/knowledge_repo/app/deploy/gunicorn.py
+++ b/knowledge_repo/app/deploy/gunicorn.py
@@ -21,12 +21,21 @@ class GunicornDeployer(BaseApplication, KnowledgeDeployer):
         BaseApplication.__init__(self)
 
     def load_config(self):
-        options = {
+        env_args = self.cfg.parser().parse_args(self.cfg.get_cmd_args_from_env())
+
+        # Load up environment configuration.
+        for key, value in vars(env_args).items():
+            if key != 'args' and value is not None:
+                self.cfg.set(key, value)
+
+        # Lastly, update the configuration with any command line settings.
+        command_line_args = {
             'bind': u'{}:{}'.format(self.host, self.port),
             'workers': self.workers,
-            'timeout': self.timeout
+            'timeout': self.timeout,
         }
-        for key, value in options.items():
+
+        for key, value in command_line_args.items():
             self.cfg.set(key, value)
 
     def load(self):

--- a/knowledge_repo/app/deploy/gunicorn.py
+++ b/knowledge_repo/app/deploy/gunicorn.py
@@ -28,14 +28,14 @@ class GunicornDeployer(BaseApplication, KnowledgeDeployer):
             if key != 'args' and value is not None:
                 self.cfg.set(key, value)
 
-        # Lastly, update the configuration with any command line settings.
-        command_line_args = {
+        # Update the configuration with the options specified via KnowledgeDeployer
+        deployer_args = {
             'bind': u'{}:{}'.format(self.host, self.port),
             'workers': self.workers,
             'timeout': self.timeout,
         }
 
-        for key, value in command_line_args.items():
+        for key, value in deployer_args.items():
             self.cfg.set(key, value)
 
     def load(self):


### PR DESCRIPTION
Description of changeset: 

This PR mimics logic [here](https://github.com/benoitc/gunicorn/blob/master/gunicorn/app/base.py#L150) to allow additional Gunicorn configuration to be defined via the `GUNICORN_CMD_ARGS` environment variable, i.e., 
```
GUNICORN_CMD_ARGS='--statsd-host=localhost:8125' knowledge_repo deploy
```

Test Plan: 

Verified that the command line args where present.

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
