### PR TITLE
Fix git reindexing using custom branch

### DIFF
--- a/knowledge_repo/repositories/gitrepository.py
+++ b/knowledge_repo/repositories/gitrepository.py
@@ -147,7 +147,7 @@ class GitKnowledgeRepository(KnowledgeRepository):
         logger.info("Fetching updates to the knowledge repository...")
         self.git_remote.fetch()
         current_branch = self.git.active_branch
-        self.git.branches.master.checkout()
+        self.git.branches[branch].checkout()
         self.git_remote.pull(branch)
         current_branch.checkout()
 


### PR DESCRIPTION
Fixes #448

`master` branch was hardcoded instead of using the provided one.

**Description of changeset:** 
A single line in `knowledge_repo/repositories/gitrepository.py` has been modified to use the correct branch.

**Test Plan:** 
- `gitrepository.py` is not currently being unitary-tested, so I did not add a test for it.
- After the patch is added, execute the steps in #448 to verify it is working.

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
