### PR TITLE
Revert "Db connection fixes"

### DIFF
--- a/knowledge_repo/app/models.py
+++ b/knowledge_repo/app/models.py
@@ -40,7 +40,6 @@ class IndexMetadata(db.Model):
 
     @classmethod
     def get(cls, type, name, default=None):
-        db.engine.dispose()
         m = db_session.query(IndexMetadata).filter(IndexMetadata.type == type).filter(IndexMetadata.name == name).first()
         if m is not None:
             return m.value
@@ -48,7 +47,6 @@ class IndexMetadata(db.Model):
 
     @classmethod
     def set(cls, type, name, value):
-        db.engine.dispose()
         m = db_session.query(IndexMetadata).filter(IndexMetadata.type == type).filter(IndexMetadata.name == name).first()
         if m is not None:
             m.value = value
@@ -59,7 +57,6 @@ class IndexMetadata(db.Model):
 
     @classmethod
     def get_last_update(cls, type, name):
-        db.engine.dispose()
         m = db_session.query(IndexMetadata).filter(IndexMetadata.type == type).filter(IndexMetadata.name == name).first()
         if m is not None:
             return m.updated_at

--- a/knowledge_repo/repositories/dbrepository.py
+++ b/knowledge_repo/repositories/dbrepository.py
@@ -65,10 +65,7 @@ class DbKnowledgeRepository(KnowledgeRepository):
 
     @property
     def revision(self):
-        self.engine.dispose()
-        result = self.session.query(func.max(self.PostRef.updated_at)).first()
-        self.session.commit()
-        return str(result[0])
+        return str(self.session.query(func.max(self.PostRef.updated_at)).first()[0])
 
     def update(self):
         pass


### PR DESCRIPTION
Reverts airbnb/knowledge-repo#445 . Looks like I should have reviewed this a bit more closely @CPapadim ! This is causing issues with the in-memory sqlite database connection, because throwing away the engine also throws away the database.

Can you see if you can fix the issue by instead re-establishing the connection from the indexing thread instead of on the model itself? [I think that's how I thought it was being done already, but obviously didn't look closely enough >.<].