### PR TITLE
Configure Travis tests for Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "2.7"
   - "3.4"
+  - "3.6"
 
 before_install:
   # We do this conditionally because it saves us some downloading if the
@@ -18,8 +19,9 @@ before_install:
   # Useful for debugging any issues with conda
   - conda info -a
   # Replace dep1 dep2 ... with your dependencies
-  - conda install -c r r
-  - conda install -c r r-knitr
+  - conda create -n testenv python=$TRAVIS_PYTHON_VERSION
+  - source activate testenv
+  - conda install -c r r r-knitr
 install:
   - pip install pycodestyle
   - pip install .[all]

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "2.7"
   - "3.4"
+  - "3.5"
   - "3.6"
 
 before_install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,9 +7,9 @@ environment:
       PYTHON_ARCH: "32"
       MINICONDA: C:\Miniconda
 
-    - PYTHON: "C:\\Python34"
-      PYTHON_VERSION: "3.4.1"
-      PYTHON_ARCH: "32"
+    - PYTHON: "C:\\Python37-x64"
+      PYTHON_VERSION: "3.7.0"
+      PYTHON_ARCH: "64"
       MINICONDA: C:\Miniconda3
 
 init:
@@ -20,8 +20,7 @@ init:
   # Useful for debugging any issues with conda
   - conda info -a
   # Replace dep1 dep2 ... with your dependencies
-  - conda install -c r r
-  - conda install -c r r-knitr
+  - conda install -c r r r-knitr
 
 install:
   - "%PYTHON%/Scripts/pip.exe install autopep8 pep8"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,8 @@ environment:
       PYTHON_ARCH: "32"
       MINICONDA: C:\Miniconda
 
-    - PYTHON: "C:\\Python37-x64"
-      PYTHON_VERSION: "3.7.0"
+    - PYTHON: "C:\\Python36-x64"
+      PYTHON_VERSION: "3.6.6"
       PYTHON_ARCH: "64"
       MINICONDA: C:\Miniconda3
 

--- a/tests/config_server.py
+++ b/tests/config_server.py
@@ -3,7 +3,7 @@ import posixpath
 # This file is only needed for setting up a dedicated server configuration
 # with support for extracting username information and emailing users.
 
-SERVER_NAME = 'localhost'
+SERVER_NAME = 'localhost.localdomain'
 
 # ---------------------------------------------------
 # Database configuration


### PR DESCRIPTION
Description of changeset: 
Travis scripts were not actually using the Python versions specified in the build matrix (`conda` was installing 3.7 for the Python 3 build).

Test Plan: 
Run CI

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
