### PR TITLE
Add explicit thumbnail resizing for thumbnails.

### DIFF
--- a/knowledge_repo/_version.py
+++ b/knowledge_repo/_version.py
@@ -39,6 +39,7 @@ __dependencies__ = [
     'werkzeug',  # Development webserver
     'gunicorn',  # Deployed webserver
     'inflection',  # String transformation library
+    'pillow',  # Image thumbnailing
 ]
 
 __optional_dependencies__ = {


### PR DESCRIPTION
Currently, when thumbnails are too large, the base64 encoded string representing the image can exceed the typical limit of 65535 characters on the thumbnail field in the model. This patch fixes this by explicitly resizing the thumbnail on index generation.

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
