### PR TITLE
Delay starting indexing until actually deploying server.

### DIFF
--- a/knowledge_repo/app/app.py
+++ b/knowledge_repo/app/app.py
@@ -191,9 +191,6 @@ class KnowledgeFlask(Flask):
                 Tag(name=tag)
             db_session.commit()
 
-        # Set up indexing timers
-        set_up_indexing_timers(self)
-
         @self.before_request
         def open_repository_session():
             if not request.path.startswith('/static'):
@@ -317,6 +314,9 @@ class KnowledgeFlask(Flask):
     def db_update_index(self, check_timeouts=True, force=False, reindex=False):
         with self.app_context():
             update_index(check_timeouts=check_timeouts, force=force, reindex=reindex)
+
+    def start_indexing(self):
+        set_up_indexing_timers(self)
 
     def check_thread_support(self, check_index=True, check_repositories=True):
         # If index database is an sqlite database, it will lock on any write action, and so breaks on multiple threads

--- a/knowledge_repo/app/deploy/common.py
+++ b/knowledge_repo/app/deploy/common.py
@@ -12,7 +12,11 @@ from knowledge_repo.utils.registry import SubclassRegisteringABCMeta
 
 def get_app_builder(uris, debug, db_uri, config, **kwargs):
     def get_app():
-        return knowledge_repo.KnowledgeRepository.for_uri(uris).get_app(db_uri=db_uri, debug=debug, config=config, **kwargs)
+        return (
+            knowledge_repo.KnowledgeRepository
+            .for_uri(uris)
+            .get_app(db_uri=db_uri, debug=debug, config=config, **kwargs)
+        )
     return get_app
 
 
@@ -24,7 +28,8 @@ class KnowledgeDeployer(with_metaclass(SubclassRegisteringABCMeta, object)):
                  port=7000,
                  workers=4,
                  timeout=60):
-        assert isinstance(knowledge_builder, (str, types.FunctionType)), u"Unknown builder type {}".format(type(knowledge_builder))
+        assert isinstance(knowledge_builder, (str, types.FunctionType)), \
+            u"Unknown builder type {}".format(type(knowledge_builder))
         self.knowledge_builder = knowledge_builder
         self.host = host
         self.port = port
@@ -36,13 +41,13 @@ class KnowledgeDeployer(with_metaclass(SubclassRegisteringABCMeta, object)):
         if engine == 'gunicorn':
             if sys.platform == 'win32':
                 raise RuntimeError(
-                    "`gunicorn` deployer is not available for Windows. Please use "
-                    "`uwsgi` or `flask` engines instead."
+                    "`gunicorn` deployer is not available for Windows. Please "
+                    "use `uwsgi` or `flask` engines instead."
                 )
             elif 'gunicorn' not in cls._registry:
                 raise RuntimeError(
-                    "`gunicorn` does not appear to be installed. Please install "
-                    "it and try again."
+                    "`gunicorn` does not appear to be installed. Please "
+                    "install it and try again."
                 )
         return cls._get_subclass_for(engine)
 
@@ -87,6 +92,7 @@ class KnowledgeDeployer(with_metaclass(SubclassRegisteringABCMeta, object)):
         out.append(self.builder_str)
         if not isinstance(self.knowledge_builder, str):
             out.append('app = %s()' % self.knowledge_builder.__name__)
+        out.append('app.start_indexing()')
 
         with open(tmp_path, 'w') as f:
             f.write(u'\n'.join(out))

--- a/knowledge_repo/app/deploy/flask.py
+++ b/knowledge_repo/app/deploy/flask.py
@@ -6,11 +6,11 @@ class FlaskDeployer(KnowledgeDeployer):
     _registry_keys = ['flask']
 
     def run(self, **kwargs):
-        app = self.app
-        return app.run(
-            debug=app.config['DEBUG'],
+        self.app.start_indexing()
+        return self.app.run(
+            debug=self.app.config['DEBUG'],
             host=self.host,
             port=self.port,
-            threaded=app.check_thread_support(),
+            threaded=self.app.check_thread_support(),
             **kwargs
         )

--- a/knowledge_repo/app/deploy/gunicorn.py
+++ b/knowledge_repo/app/deploy/gunicorn.py
@@ -46,4 +46,5 @@ class GunicornDeployer(BaseApplication, KnowledgeDeployer):
     def run(self):
         if not self.app.check_thread_support():
             raise RuntimeError("Database configuration is not suitable for deployment (not thread-safe).")
+        self.app.start_indexing()
         return BaseApplication.run(self)


### PR DESCRIPTION
The current implementation of multi-threaded indexing is triggered at instance creation time, instead of deployment time, breaking some of the useful utilities in the `knowledge_repo` script including forcing a reindex. This patch defers index initialisation until deployment.

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
