### PR TITLE
Subtract 1 from months when making JavaScript Dates for use in Google charts

### DIFF
--- a/knowledge_repo/app/templates/stats.html
+++ b/knowledge_repo/app/templates/stats.html
@@ -51,7 +51,7 @@ function drawChart() {
   data.addColumn('number', 'Pageviews');
   data.addRows([
           {%- for k, v in daily_pageviews.items() %}
-          [new Date({{ k.year }}, {{ k.month }}, {{ k.day }}), {{ v }}],
+          [new Date({{ k.year }}, {{ k.month - 1 }}, {{ k.day }}), {{ v }}],
           {%- endfor %}
   ]);
   data.sort(0);
@@ -68,7 +68,7 @@ function drawChart() {
   data.addColumn('number', 'Updated_at')
   data.addRows([
           {%- for k, v in weekly_posts_created_and_updated.items() %}
-          [new Date({{ k.year }}, {{ k.month }}, {{ k.day }}), {{ v[0]}}, {{ v[1] }}],
+          [new Date({{ k.year }}, {{ k.month - 1 }}, {{ k.day }}), {{ v[0]}}, {{ v[1] }}],
           {%- endfor %}
   ]);
   data.sort(0);
@@ -84,7 +84,7 @@ function drawChart() {
   data.addColumn('number', '# Posts')
   data.addRows([
           {%- for k, v in weekly_cumulative_posts.items() %}
-          [new Date({{ k.year }}, {{ k.month }}, {{ k.day }}), {{ v }}],
+          [new Date({{ k.year }}, {{ k.month - 1 }}, {{ k.day }}), {{ v }}],
           {%- endfor %}
   ]);
   data.sort(0);
@@ -100,7 +100,7 @@ function drawChart() {
   data.addColumn('number', 'Pageviews');
   data.addRows([
           {%- for k, v in weekly_pageviews.items() %}
-          [new Date({{ k.year }}, {{ k.month }}, {{ k.day }}), {{ v }} ],
+          [new Date({{ k.year }}, {{ k.month - 1 }}, {{ k.day }}), {{ v }} ],
           {%- endfor %}
   ]);
   data.sort(0);


### PR DESCRIPTION
Subtract 1 from months when making JavaScript Dates for use in Google charts. JS months are 0-indexed.

Description of changeset: 

I believe this resolves https://github.com/airbnb/knowledge-repo/issues/278
This seems to be the jinja2 way of subtracting from a variable's value:
http://jinja.pocoo.org/docs/2.10/templates/#math

Test Plan: 

`./run-tests.sh` passes. I admit I'm not sure how to run the locally built copy of knowledge repo to check the change.

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
