### PR TITLE
Fix sorting by 'views' column in Table view

### DIFF
--- a/knowledge_repo/app/utils/posts.py
+++ b/knowledge_repo/app/utils/posts.py
@@ -89,8 +89,8 @@ def get_posts(feed_params):
         (join_table, join_on) = joins[sort_by]
 
         query = (db_session.query(Post, order_col)
-                 .outerjoin(join_table, Post.path == join_on))
-        query = query.group_by(Post.path)
+                 .outerjoin(join_table, Post.id == join_on))
+        query = query.group_by(Post.id)
 
     # sort order
     if order_col is not None:

--- a/knowledge_repo/app/utils/posts.py
+++ b/knowledge_repo/app/utils/posts.py
@@ -67,6 +67,7 @@ def get_posts(feed_params):
     join_order_col = {
         "uniqueviews": func.count(distinct(PageView.user_id)),
         "allviews": func.count(PageView.object_id),
+        "views": func.count(PageView.object_id),
         "upvotes": func.count(Vote.object_id),
         "comments": func.count(Comment.post_id)
     }
@@ -80,6 +81,7 @@ def get_posts(feed_params):
         joins = {
             "uniqueviews": (PageView, PageView.object_id),
             "allviews": (PageView, PageView.object_id),
+            "views": (PageView, PageView.object_id),
             "upvotes": (Vote, Vote.object_id),
             "comments": (Comment, Comment.post_id)
         }


### PR DESCRIPTION
Description of changeset: 

I believe this could resolve https://github.com/airbnb/knowledge-repo/issues/363
The issue is that `index-table.html` uses these column names when forming the `sort_by` query parameter ...
```
var col_names = ['Title', 'Author', 'CreatedAt', 'UpdatedAt', 'Views', 'Upvotes', 'Comments']
```
... but `posts.py` is expecting sort_by columns like ...
```
    post_properties = {
        "updated_at": Post.updated_at,
        "created_at": Post.created_at,
        "title": Post.title,
    }
    join_order_col = {
        "uniqueviews": func.count(distinct(PageView.user_id)),
        "allviews": func.count(PageView.object_id),
        "upvotes": func.count(Vote.object_id),
        "comments": func.count(Comment.post_id)
    }
```

`views` isn't among the options but `uniqueviews` and `allviews` are. I think this should be an alias for `allviews`?

Test Plan: 

`./run_tests.sh` passes, but I am not sure how to run this locally to test the sorting.

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
