### PR TITLE
Added -p parameter to update documentation

### DIFF
--- a/docs/workflows/writing.rst
+++ b/docs/workflows/writing.rst
@@ -113,7 +113,7 @@ command. This will allow the add operation to override exiting knowledge posts.
 
 .. code-block:: shell
 
-  $ knowledge_repo --repo <repo_path> add --update <file with format {ipynb, Rmd, md}> <location in knowledge repo>
+  $ knowledge_repo --repo <repo_path> add --update <file with format {ipynb, Rmd, md}> -p <location in knowledge repo>
 
 Previewing
 ^^^^^^^^^^


### PR DESCRIPTION
Description of changeset: Updated the documentation for updating a post by adding the `-p` parameter because running as specified in documentation throws `knowledge_repo: error: unrecognized arguments:`

Test Plan: 


Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
