### PR TITLE
Fix typo "nane"->"name"

### DIFF
--- a/knowledge_repo/app/templates/index-base.html
+++ b/knowledge_repo/app/templates/index-base.html
@@ -35,6 +35,7 @@
         <a href="{{ "#" if (page == page_count) else modify_query(start=page*results) }}" class="pagination-stepper{% if page == page_count %} disabled{% endif %}"{% if page == page_count %} onclick="return false;"{% endif %}>
           <i class="glyphicon glyphicon-chevron-right"></i>
         </a>
+        
       </div>
 
     {% endif %}
@@ -56,7 +57,7 @@
         </a>
         <a href="/cluster" class="btn btn-default btn-cluster no-underline" role="button">
           <i class="glyphicon glyphicon-post-org glyphicon-th-list"></i>
-          <span class="index-view-nane"> Cluster </span>
+          <span class="index-view-name"> Cluster </span>
         </a>
       </div>
     </div>

--- a/knowledge_repo/app/templates/index-base.html
+++ b/knowledge_repo/app/templates/index-base.html
@@ -35,7 +35,6 @@
         <a href="{{ "#" if (page == page_count) else modify_query(start=page*results) }}" class="pagination-stepper{% if page == page_count %} disabled{% endif %}"{% if page == page_count %} onclick="return false;"{% endif %}>
           <i class="glyphicon glyphicon-chevron-right"></i>
         </a>
-        
       </div>
 
     {% endif %}


### PR DESCRIPTION
The "Cluster" button isn't receiving the same margin between lable and icon as "Card" and "Table".

<img width="444" alt="screen shot 2019-01-03 at 8 07 31 pm" src="https://user-images.githubusercontent.com/8676510/50669482-7344ab00-0f93-11e9-94cc-70870e6118be.png">

Description of changeset: 

Test Plan: 

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
