### PR TITLE
fix header extraction in `KnowledgePost.write`

### DIFF
--- a/knowledge_repo/post.py
+++ b/knowledge_repo/post.py
@@ -291,7 +291,11 @@ class KnowledgePost(object):
         md = md.strip()
 
         if not headers:
-            headers = self._get_headers_from_yaml(md)
+            mtch = re.match('^---\n[\\s\\S]+?---\n', md)
+            if not mtch:
+                raise ValueError("YAML header is missing. Please ensure that the top of your post has a header of the following form:\n" + HEADER_SAMPLE)
+            md_head = mtch.group(0)
+            headers = self._get_headers_from_yaml(md_head)
 
         md = re.sub(r'^---\n[\s\S]+?---\n', '', md, count=1)
 


### PR DESCRIPTION
Description of changeset: 
Potential fix for #483 

I ran into the same behavior today as I did in #483 with different unicode character in the body. I'm not sure if other people are running into the same errors as me but this seems to fix the problem. 

I copied the logic in the `KnowledgePost.read` function into the `KnowledgePost.write` function in order to extract just the header which is passed into `KnowledgePost._get_headers_from_yaml` (which was where the code was breaking). This allowed me to have unicode characters in the rest of the notebook and still have the notebook processed correctly.

Let me know if this makes sense, happy to rework this as needed

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
