### PR TITLE
Adjust regex matching markdown images to less eagerly match beyond the tag in brackets

### DIFF
--- a/knowledge_repo/postprocessors/extract_images.py
+++ b/knowledge_repo/postprocessors/extract_images.py
@@ -54,7 +54,7 @@ class ExtractImages(KnowledgePostProcessor):
             # The src attribute is exected to always be surrounded by quotes.
             r'<img\s+(?:\w+(?:=([\'\"])?(?(1)(?:(?!\1).)*?\1|[^>]*?))?\s+?)*src=([\'\"])(?P<src>(?:(?!\2).)*?)\2(?:\s+\w+(?:=([\'\"])?(?(1)(?:(?!\4).)*?\4|[^>]*?))?)*\s*\/?>'
         ))
-        images.extend(self.collect_images_for_pattern(md, r'\!\[[\s\S]*?\]\((?P<src>[^\)]*)\)'))
+        images.extend(self.collect_images_for_pattern(md, r'\!\[[^\]]*?\]\((?P<src>[^\)]*)\)'))
         return sorted(images, key=lambda x: x['offset'])
 
     def collect_images_for_pattern(self, md, pattern=None):


### PR DESCRIPTION
Description of changeset: 

When adding an ipython notebook, a postprocessor scans for images in the JSON by searching with a regex for markdown-style images like `[tag](url)`. The regex is as you see below. 

I had a cell with some inline Javascript like: `![123]...lots of stuff...](...stuff...)`. This matched as an image because the reluctant quantifier still forces it to expand the match of the tag until it sees "](". It shouldn't match.

The current regex looks for "space, or not space" in between the square braces. That didn't sound right -- why not "."? But in any event my guess is the intent is to match "anything except a closing square brace".

This at least made my case work. Submitted for your consideration.


Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
