### PR TITLE
Fix CRLF line ending issue for windows users

### DIFF
--- a/knowledge_repo/post.py
+++ b/knowledge_repo/post.py
@@ -247,11 +247,11 @@ class KnowledgePost(object):
             md = ''
         else:
             md = decode(self._read_ref('knowledge.md'))
-            mtch = re.match('^---\n[\\s\\S]+?---\n', md)
+            mtch = re.match('^---(\n|\r)[\\s\\S]+?---(\n|\r)', md)
             if not mtch:
                 raise ValueError("YAML header is missing. Please ensure that the top of your post has a header of the following form:\n" + HEADER_SAMPLE)
             if not headers:
-                md = re.sub('^---\n[\\s\\S]+?---\n', '', md, count=1)
+                md = re.sub('^---(\n|\r)[\\s\\S]+?---(\n|\r)', '', md, count=1)
             if not body:
                 md = mtch.group(0)
         if images:
@@ -293,7 +293,7 @@ class KnowledgePost(object):
         if not headers:
             headers = self._get_headers_from_yaml(md)
 
-        md = re.sub(r'^---\n[\s\S]+?---\n', '', md, count=1)
+        md = re.sub(r'^---(\n|\r)[\s\S]+?---(\n|\r)', '', md, count=1)
 
         headers = self._verify_headers(headers, interactive=interactive)
 


### PR DESCRIPTION
Description of changeset:
This is a quick patch for #489, which was an issue for me as well. I just updated the regex in the `KnowledgePost` `read`/`write` methods to match `\r` in addition to `\n` to avoid having to manually deal with CRLF/LF conversions.

Test Plan: 
1. Build a knowledge repo where the `knowledge.md` file has CRLF line endings.
2. Run `knowledge_repo --repo <repo-path> preview <post-path>` (this was the command that failed for me and in the original issue) to make sure YAML headers are now correctly extracted.

Full disclosure, I haven't tested the `write` method with the regex change, but I assumed it was best to keep the three header regexes consistent.

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
