### PR TITLE
Collapse Code as Default Display Option

### DIFF
--- a/knowledge_repo/app/config_defaults.py
+++ b/knowledge_repo/app/config_defaults.py
@@ -311,3 +311,9 @@ WEB_EDITOR_PREFIXES = ['webposts']
 # Posts with certain tags can be excluded from showing up
 # in the app. This can be useful for security purposes
 EXCLUDED_TAGS = ['private']
+
+
+# -------------
+# Collapse Code as Default Display Option
+# -------------
+COLLAPSE_CODE_DEFAULT = False

--- a/knowledge_repo/app/routes/posts.py
+++ b/knowledge_repo/app/routes/posts.py
@@ -113,7 +113,8 @@ def render(path):
                                is_private=(post.private == 1),
                                is_author=is_author,
                                can_download=permissions.post_download.can(),
-                               downloads=post.kp.src_paths)
+                               downloads=post.kp.src_paths,
+                               collapse_code=current_app.config['COLLAPSE_CODE_DEFAULT'])
     return rendered
 
 

--- a/knowledge_repo/app/templates/markdown-rendered.html
+++ b/knowledge_repo/app/templates/markdown-rendered.html
@@ -177,7 +177,7 @@ $(document).on('ready', function(){
   $maindiv = $('.renderedMarkdown');
   $maindiv.prepend("<div class=\"codetoggleall\">Collapse All Code</div>");
 
-  $('.codetoggleall').click(function() {
+  var toggleCode = function() {
     var label = $(this).html();
     if (label.indexOf("Expand All Code") >= 0) {
       $(this).html(label.replace("Expand All Code", "Collapse All Code"));
@@ -198,7 +198,13 @@ $(document).on('ready', function(){
 		  $(this).html(label.replace("Collapse", "Expand"));
 	  });
     }
-  });
+  };
+
+  $('.codetoggleall').click(toggleCode);
+
+  {% if collapse_code %}
+    $('.codetoggleall').trigger( "click" )
+  {% endif %}
 })
 
 //Turn all the headers to be links


### PR DESCRIPTION
Description of changeset: Configuration option to collapse all code in notebook as default display option for a knowledge post.

Test Plan: 


Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
