### PR TITLE
Add policy for viewing tag pages anonymously

### DIFF
--- a/knowledge_repo/app/config_defaults.py
+++ b/knowledge_repo/app/config_defaults.py
@@ -212,6 +212,9 @@ POLICY_ANONYMOUS_VIEW_POST = True
 # Should anonymous users be able to view overall statistics
 POLICY_ANONYMOUS_VIEW_STATS = True
 
+# Should anonymous users be able to view tag pages
+POLICY_ANONYMOUS_VIEW_TAGS = True
+
 # Should anonymous users be able to download posts (or their source)
 POLICY_ANONYMOUS_DOWNLOADS = False
 

--- a/knowledge_repo/app/permissions.py
+++ b/knowledge_repo/app/permissions.py
@@ -9,6 +9,9 @@ stats_view = Permission(roles.stats_view)
 # Index permissions
 index_view = Permission(roles.index_view)
 
+# Tags permissions
+tags_view = Permission(roles.tags_view)
+
 # Post permissions
 post_comment = Permission(roles.post_comment)
 post_edit = Permission(roles.post_edit)

--- a/knowledge_repo/app/roles.py
+++ b/knowledge_repo/app/roles.py
@@ -11,6 +11,9 @@ stats_view = RoleNeed('stats_view')
 # Index roles
 index_view = RoleNeed('index_view')
 
+# Tags roles
+tags_view = RoleNeed('tags_view')
+
 # Post roles
 post_comment = RoleNeed('post_comment')
 post_edit = RoleNeed('post_edit')

--- a/knowledge_repo/app/routes/tags.py
+++ b/knowledge_repo/app/routes/tags.py
@@ -116,7 +116,7 @@ def delete_tags_from_posts():
 
 @blueprint.route('/tag_pages')
 @PageView.logged
-@permissions.post_comment.require()
+@permissions.tags_view.require()
 def render_tag_pages():
     feed_params = from_request_get_feed_params(request)
     start = feed_params['start']
@@ -136,7 +136,7 @@ def render_tag_pages():
     tag_description = tag_obj.description
 
     # Get subscription status
-    subscribed = tag in feed_params["subscriptions"]
+    subscribed = tag in feed_params.get("subscriptions", [])
 
     # get all files with given tag
     tag_posts = tag_obj.posts

--- a/knowledge_repo/app/utils/auth.py
+++ b/knowledge_repo/app/utils/auth.py
@@ -62,6 +62,8 @@ def populate_identity_roles(identity, user=None):
             identity.provides.add(roles.post_view)
         if current_app.config['POLICY_ANONYMOUS_VIEW_STATS']:
             identity.provides.add(roles.stats_view)
+        if current_app.config['POLICY_ANONYMOUS_VIEW_TAGS']:
+            identity.provides.add(roles.tags_view)
         if current_app.config['POLICY_ANONYMOUS_DOWNLOADS']:
             identity.provides.add(roles.post_download)
 

--- a/knowledge_repo/app/utils/auth.py
+++ b/knowledge_repo/app/utils/auth.py
@@ -75,6 +75,7 @@ def populate_identity_roles(identity, user=None):
         identity.provides.add(roles.post_comment)
         identity.provides.add(roles.post_download)
         identity.provides.add(roles.stats_view)
+        identity.provides.add(roles.tags_view)
 
         # TODO: Populate group permissions, and port existing group admin
         # code to roles.


### PR DESCRIPTION
Description of changeset: 
Potential fix for #493. 

This change creates a new policy for viewing /tag_pages anonymously, and changes the permissions required to view /tag_pages from post_comment to tags_view.

Test Plan: 
I didn't see any existing tests around policies/roles/permissions, so I just confirmed that the existing test suite still passes with these changes.

Auto-reviewers: @NiharikaRay @matthewwardrop @earthmancash @danfrankj
