### PR TITLE
bugfix to the username_parse method

### DIFF
--- a/knowledge_repo/config_defaults.py
+++ b/knowledge_repo/config_defaults.py
@@ -56,7 +56,7 @@ def username_parse(repo, username):
     if not re.match(repo.config.username_pattern, username):
         raise ValueError(
             "Username '{}' does not follow the required pattern: '{}'"
-            .format(repo.config.username_pattern)
+            .format(username, repo.config.username_pattern)
         )
     return username
 


### PR DESCRIPTION
Tried to use this method to enforce consistency in usernames but it has a bug -- seems like in general this functionality is somewhat deprecated but as long as it is still around, might as well raise the correct error! 

