### PR TITLE
Add pageview indexes

### DIFF
--- a/knowledge_repo/app/migrations/alembic.ini
+++ b/knowledge_repo/app/migrations/alembic.ini
@@ -7,6 +7,7 @@
 # set to 'true' to run the environment during
 # the 'revision' command, regardless of autogenerate
 # revision_environment = false
+script_location = .
 
 
 # Logging configuration

--- a/knowledge_repo/app/migrations/versions/eb39ac93fc39_add_pageview_indexes.py
+++ b/knowledge_repo/app/migrations/versions/eb39ac93fc39_add_pageview_indexes.py
@@ -1,0 +1,26 @@
+"""add_pageview_indexes
+
+Revision ID: eb39ac93fc39
+Revises: d15f6cac07e1
+Create Date: 2019-11-15 15:30:55.010491
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'eb39ac93fc39'
+down_revision = 'd15f6cac07e1'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_index(
+        "object_id_type_action_index",
+        "pageviews",
+        ["object_id", "object_type", "object_action"],
+        unique=False,
+    )
+
+def downgrade():
+    op.drop_index("object_id_type_action_index", table_name="pageviews")

--- a/knowledge_repo/app/models.py
+++ b/knowledge_repo/app/models.py
@@ -10,7 +10,7 @@ from flask_login import UserMixin
 from flask_sqlalchemy import SQLAlchemy
 from collections import defaultdict
 
-from sqlalchemy import func, distinct, and_, select, UniqueConstraint
+from sqlalchemy import func, distinct, and_, select, Index, UniqueConstraint
 
 from knowledge_repo._version import __version__
 from knowledge_repo.repository import KnowledgeRepository
@@ -155,6 +155,8 @@ class PageView(db.Model):
     ip_address = db.Column(db.String(64))
     created_at = db.Column(db.DateTime, default=func.now())
     version = db.Column(db.String(100), default=__version__)
+
+    __table_args__ = (Index("object_id_type_action_index", object_id, object_type, object_action),)
 
     class logged(object):
 


### PR DESCRIPTION
Description of changeset: 
Addes indexes to speed up queries that take >90% of the load time for the homepage
![image](https://user-images.githubusercontent.com/7409244/68984513-60ab1d00-07c5-11ea-8828-10a0d081ce31.png)

Test Plan: 
CI and tested in Airbnb's environment

@john-bodley @serenajiang @danfrankj 
