### PR TITLE
Fix deprecated werkzeug imports removed in version 1.0.0

### DIFF
--- a/knowledge_repo/app/app.py
+++ b/knowledge_repo/app/app.py
@@ -17,7 +17,10 @@ from flask_principal import Principal, identity_loaded, Identity, AnonymousIdent
 from alembic import command
 from alembic.migration import MigrationContext
 from datetime import datetime
-from werkzeug.urls import url_encode
+try:
+    from werkzeug import url_encode
+except ImportError:
+    from werkzeug.urls import url_encode
 
 import knowledge_repo
 from . import routes

--- a/knowledge_repo/app/app.py
+++ b/knowledge_repo/app/app.py
@@ -17,7 +17,7 @@ from flask_principal import Principal, identity_loaded, Identity, AnonymousIdent
 from alembic import command
 from alembic.migration import MigrationContext
 from datetime import datetime
-from werkzeug import url_encode
+from werkzeug.urls import url_encode
 
 import knowledge_repo
 from . import routes

--- a/knowledge_repo/app/routes/editor.py
+++ b/knowledge_repo/app/routes/editor.py
@@ -6,7 +6,10 @@ from builtins import str
 from datetime import datetime
 from flask import request, render_template, Blueprint, current_app, url_for, send_from_directory, g
 from sqlalchemy import or_
-from werkzeug.utils import secure_filename
+try:
+    from werkzeug import secure_filename
+except ImportError:
+    from werkzeug.utils import secure_filename
 
 from knowledge_repo.post import KnowledgePost
 from .. import permissions

--- a/knowledge_repo/app/routes/editor.py
+++ b/knowledge_repo/app/routes/editor.py
@@ -6,7 +6,7 @@ from builtins import str
 from datetime import datetime
 from flask import request, render_template, Blueprint, current_app, url_for, send_from_directory, g
 from sqlalchemy import or_
-from werkzeug import secure_filename
+from werkzeug.utils import secure_filename
 
 from knowledge_repo.post import KnowledgePost
 from .. import permissions


### PR DESCRIPTION
Fix deprecated Werkzeug imports removed in version 1.0.0:
- `werkzeug.url_encode` -> `werkzeug.urls.url_encode`
- `werkzeug.secure_filename` -> `werkzeug.utils.secure_filename`

This PR solves issue https://github.com/airbnb/knowledge-repo/issues/531.