### PR TITLE
[schema] Increasing email body size

### DIFF
--- a/knowledge_repo/app/migrations/versions/009eafe4838f_add_support_for_external_authentication.py
+++ b/knowledge_repo/app/migrations/versions/009eafe4838f_add_support_for_external_authentication.py
@@ -15,29 +15,28 @@ import sqlalchemy as sa
 
 
 def upgrade():
-    # Migrate from `usernames` to `identifiers`
     op.alter_column('users', 'username', new_column_name='identifier', existing_type=sa.String(length=500))
-    op.add_column('users', sa.Column('username', sa.String(length=500), nullable=True))
 
-    # Add new fields
-    op.add_column('users', sa.Column('password', sa.String(length=500), nullable=True))
-    op.add_column('users', sa.Column('active', sa.Boolean(), nullable=True))
-    op.add_column('users', sa.Column('name', sa.String(length=500), nullable=True))
-    op.add_column('users', sa.Column('preferred_name', sa.String(length=500), nullable=True))
-    op.add_column('users', sa.Column('avatar_uri', sa.Text(), nullable=True))
-    op.add_column('users', sa.Column('email', sa.String(length=500), nullable=True))
-    op.add_column('users', sa.Column('last_login_at', sa.DateTime(), nullable=True))
+    with op.batch_alter_table('users') as batch_op:
+        batch_op.add_column(sa.Column('username', sa.String(length=500), nullable=True))
+        batch_op.add_column(sa.Column('password', sa.String(length=500), nullable=True))
+        batch_op.add_column(sa.Column('active', sa.Boolean(), nullable=True))
+        batch_op.add_column(sa.Column('name', sa.String(length=500), nullable=True))
+        batch_op.add_column(sa.Column('preferred_name', sa.String(length=500), nullable=True))
+        batch_op.add_column(sa.Column('avatar_uri', sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column('email', sa.String(length=500), nullable=True))
+        batch_op.add_column(sa.Column('last_login_at', sa.DateTime(), nullable=True))
 
 
 def downgrade():
-    op.drop_column('users', 'username')
-    op.alter_column('users', 'identifier', new_column_name='username', existing_type=sa.String(length=500))
+    with op.batch_alter_table('users') as batch_op:
+        batch_op.drop_column('username')
+        batch_op.drop_column('preferred_name')
+        batch_op.drop_column('password')
+        batch_op.drop_column('name')
+        batch_op.drop_column('last_login_at')
+        batch_op.drop_column('email')
+        batch_op.drop_column('active')
+        batch_op.drop_column('avatar_uri')
 
-    # Remove new fields
-    op.drop_column('users', 'preferred_name')
-    op.drop_column('users', 'password')
-    op.drop_column('users', 'name')
-    op.drop_column('users', 'last_login_at')
-    op.drop_column('users', 'email')
-    op.drop_column('users', 'active')
-    op.drop_column('users', 'avatar_uri')
+    op.alter_column('users', 'identifier', new_column_name='username', existing_type=sa.String(length=500))

--- a/knowledge_repo/app/migrations/versions/1b385158fd32_assoc_rename_and_uuid_column.py
+++ b/knowledge_repo/app/migrations/versions/1b385158fd32_assoc_rename_and_uuid_column.py
@@ -17,22 +17,30 @@ import sqlalchemy as sa
 def upgrade():
     op.rename_table('knowledge_post_author', 'assoc_post_author')
     op.rename_table('knowledge_post_tags', 'assoc_post_tag')
-    op.add_column('assoc_post_author', sa.Column('order', sa.Integer(), nullable=True))
 
-    op.add_column('posts', sa.Column('uuid', sa.String(length=100), nullable=True))
-    op.create_unique_constraint(None, 'posts', ['uuid'])
+    with op.batch_alter_table('assoc_post_author') as batch_op:
+        batch_op.add_column(sa.Column('order', sa.Integer(), nullable=True))
 
-    op.add_column('pageviews', sa.Column('object_action', sa.String(length=100), nullable=True))
-    op.add_column('pageviews', sa.Column('version', sa.String(length=100), nullable=True))
+    with op.batch_alter_table('posts') as batch_op:
+        batch_op.add_column(sa.Column('uuid', sa.String(length=100), nullable=True))
+        batch_op.create_unique_constraint('uq_uuid', ['uuid'])
+
+    with op.batch_alter_table('pageviews') as batch_op:
+        batch_op.add_column(sa.Column('object_action', sa.String(length=100), nullable=True))
+        batch_op.add_column(sa.Column('version', sa.String(length=100), nullable=True))
 
 
 def downgrade():
-    op.drop_column('assoc_post_author', 'order')
+    with op.batch_alter_table('assoc_post_author') as batch_op:
+        batch_op.drop_column('order')
+
     op.rename_table('assoc_post_author', 'knowledge_post_author')
     op.rename_table('assoc_post_tag', 'knowledge_post_tags')
 
-    op.drop_constraint(None, 'posts', type_='unique')
-    op.drop_column('posts', 'uuid')
+    with op.batch_alter_table('posts') as batch_op:
+        batch_op.drop_constraint('uq_uuid', type_='unique')
+        batch_op.drop_column('uuid')
 
-    op.drop_column('pageviews', 'object_action')
-    op.drop_column('pageviews', 'version')
+    with op.batch_alter_table('pageviews') as batch_op:
+        batch_op.drop_column('pageviews', 'object_action')
+        batch_op.drop_column('pageviews', 'version')

--- a/knowledge_repo/app/migrations/versions/36baffc5df12_add_groups_permissions_to_posts.py
+++ b/knowledge_repo/app/migrations/versions/36baffc5df12_add_groups_permissions_to_posts.py
@@ -33,11 +33,15 @@ def upgrade():
     sa.ForeignKeyConstraint(['group_id'], ['groups.id'], ),
     sa.ForeignKeyConstraint(['post_id'], ['posts.id'], )
     )
-    op.add_column(u'posts', sa.Column('private', sa.Integer(), nullable=True))
+
+    with op.batch_alter_table('posts') as batch_op:
+        batch_op.add_column(sa.Column('private', sa.Integer(), nullable=True))
 
 
 def downgrade():
-    op.drop_column(u'posts', 'private')
+    with op.batch_alter_table('posts') as batch_op:
+        op.drop_column('private')
+
     op.drop_table('assoc_post_group')
     op.drop_table('assoc_group_user')
     op.drop_table('groups')

--- a/knowledge_repo/app/migrations/versions/38eeba774226_resize_email_text.py
+++ b/knowledge_repo/app/migrations/versions/38eeba774226_resize_email_text.py
@@ -1,0 +1,36 @@
+"""resize_email_text
+
+Revision ID: 38eeba774226
+Revises: eb39ac93fc39
+Create Date: 2020-03-11 09:46:29.112836
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '38eeba774226'
+down_revision = 'eb39ac93fc39'
+
+from alembic import op
+import sqlalchemy as sa
+
+from knowledge_repo.utils.types import MediumText
+
+
+def upgrade():
+    with op.batch_alter_table('emails') as batch_op:
+        batch_op.alter_column(
+            'text',
+            existing_type=sa.Text(),
+            type_=MediumText(),
+            existing_nullable=True,
+        )
+
+
+def downgrade():
+    with op.batch_alter_table('emails') as batch_op:
+        batch_op.alter_column(
+            'text',
+            existing_type=MediumText(),
+            type_=sa.Text(),
+            existing_nullable=True,
+        )

--- a/knowledge_repo/app/migrations/versions/9715822acf6c_add_errorlog_table.py
+++ b/knowledge_repo/app/migrations/versions/9715822acf6c_add_errorlog_table.py
@@ -25,11 +25,15 @@ def upgrade():
         sa.Column('created_at', sa.DateTime(), nullable=True),
         sa.PrimaryKeyConstraint('id')
     )
-    op.add_column('pageviews', sa.Column('id_errorlog', sa.Integer(), nullable=True))
-    op.drop_column('pageviews', 'error_message')
+
+    with op.batch_alter_table('pageviews') as batch_op:
+        batch_op.add_column(sa.Column('id_errorlog', sa.Integer(), nullable=True))
+        batch_op.drop_column('error_message')
 
 
 def downgrade():
-    op.add_column('pageviews', sa.Column('error_message', sa.Text(), nullable=True))
-    op.drop_column('pageviews', 'id_errorlog')
+    with op.batch_alter_table('pageviews') as batch_op:
+        batch_op.add_column(sa.Column('error_message', sa.Text(), nullable=True))
+        batch_op.drop_column('id_errorlog')
+
     op.drop_table('errorlog')

--- a/knowledge_repo/app/models.py
+++ b/knowledge_repo/app/models.py
@@ -14,6 +14,7 @@ from sqlalchemy import func, distinct, and_, select, Index, UniqueConstraint
 
 from knowledge_repo._version import __version__
 from knowledge_repo.repository import KnowledgeRepository
+from knowledge_repo.utils.types import MediumText
 from .proxies import current_user, current_repo, db_session
 from .utils.models import unique_constructor
 from .utils.search import get_keywords
@@ -633,7 +634,7 @@ class Email(db.Model):
     object_type = db.Column(db.String(100))
     sent_at = db.Column(db.DateTime, default=func.now())
     subject = db.Column(db.Text)
-    text = db.Column(db.Text)
+    text = db.Column(MediumText())
 
 
 @unique_constructor(

--- a/knowledge_repo/utils/types.py
+++ b/knowledge_repo/utils/types.py
@@ -1,8 +1,15 @@
 import sys
 
+from sqlalchemy import Text
+from sqlalchemy.dialects.mysql import MEDIUMTEXT
+
 __all__ = ['str_types']
 
 if sys.version_info.major > 2:
     str_types = (str,)
 else:
     str_types = (str, unicode)
+
+
+def MediumText():
+    return Text().with_variant(MEDIUMTEXT(), 'mysql')


### PR DESCRIPTION
Description of changeset: 

Currently the email body is defined as a `TEXT` field which for MySQL is limited to ~ 64 KB. This is problematic as the body includes the embedded images from the post and if they're too large can result in a blocking MySQL error which prevents the repo from being reindexed. 

This PR changes the schema of the `emails.text` column to be `MEDIUMTEXT` (~ 16 MB) for MySQL instances.

Test Plan: 

Ran `knowledge_repo --repo={} --dev db_upgrade` locally using both MySQL and SQLite and verified the schema.

to: @etr2460 @NiharikaRay 