### PR TITLE
[fix] Removing tests/test_repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ pip-delete-this-directory.txt
 
 # Unit test / coverage reports
 htmlcov/
+tests/test_repo/
 .tox/
 .coverage
 .coverage.*


### PR DESCRIPTION
Description of changeset: 

Removing erroneous `tests/test_repo` introduced accidentally in  https://github.com/airbnb/knowledge-repo/pull/537 which is a byproduct of running the `run_tests.sh` script.

Test Plan: 

CI.

to: @etr2460 

