### PR TITLE
Improve subscription emails (revised)

### DIFF
--- a/knowledge_repo/_version.py
+++ b/knowledge_repo/_version.py
@@ -27,7 +27,7 @@ __dependencies__ = [
     'tabulate',  # Rendering information prettily in knowledge_repo script
     'pyyaml',  # Used to configure knowledge repositories
     'cooked_input',  # Used for interactive input from user in CLI tooling
-    'requests', # Used for downloading images
+    'requests',  # Used for downloading images
 
     # Flask App Dependencies
     'flask',  # Main flask framework

--- a/knowledge_repo/_version.py
+++ b/knowledge_repo/_version.py
@@ -27,6 +27,7 @@ __dependencies__ = [
     'tabulate',  # Rendering information prettily in knowledge_repo script
     'pyyaml',  # Used to configure knowledge repositories
     'cooked_input',  # Used for interactive input from user in CLI tooling
+    'requests', # Used for downloading images
 
     # Flask App Dependencies
     'flask',  # Main flask framework

--- a/knowledge_repo/app/templates/email_templates/subscription_email.html
+++ b/knowledge_repo/app/templates/email_templates/subscription_email.html
@@ -1,0 +1,19 @@
+<table border="0" cellpadding="0" cellspacing="0" style="font-size: 13px">
+    <tbody>
+        <tr>
+            <td style="vertical-align: center; text-align: center; width: 150px">
+                <a href="{{ url_for('posts.render', path=page_id, _external=True) }}">
+                    <img style="border: 0; max-width: 140" src="cid:Thumb" />
+                </a>
+            </td>
+            <td style="padding-left: 10px">
+                <p style="font-size: 15px; font-weight: bold">{{ post_title }}</p>
+                <p style="margin: 5px 0">
+                    Author(s): <span style="font-style: italic; font-weight: bold">{{ post_authors|join(', ') }}</span>
+                    | Tag(s): <span style="font-style: italic">{{ post_tags|join(', ') }}</span>
+                </p>
+                <p>{{ post_tldr | safe }} <a href="{{ url_for('posts.render', path=page_id, _external=True) }}">View post</a></p>
+            </td>
+        </tr>
+    </tbody>
+</table>

--- a/knowledge_repo/app/templates/email_templates/subscription_email.html
+++ b/knowledge_repo/app/templates/email_templates/subscription_email.html
@@ -3,7 +3,7 @@
         <tr>
             <td style="vertical-align: center; text-align: center; width: 150px">
                 <a href="{{ url_for('posts.render', path=page_id, _external=True) }}">
-                    <img style="border: 0; max-width: 140" src="cid:Thumb" />
+                    <img height="200" src="cid:Thumb" />
                 </a>
             </td>
             <td style="padding-left: 10px">

--- a/knowledge_repo/app/templates/email_templates/subscription_email.html
+++ b/knowledge_repo/app/templates/email_templates/subscription_email.html
@@ -9,7 +9,7 @@
             <td style="padding-left: 10px">
                 <p style="font-size: 15px; font-weight: bold">{{ post_title }}</p>
                 <p style="margin: 5px 0">
-                    Author(s): <span style="font-style: italic; font-weight: bold">{{ post_authors|join(', ') }}</span>
+                    Author(s): <span style="font-style: italic">{{ post_authors|join(', ') }}</span>
                     | Tag(s): <span style="font-style: italic">{{ post_tags|join(', ') }}</span>
                 </p>
                 <p>{{ post_tldr | safe }} <a href="{{ url_for('posts.render', path=page_id, _external=True) }}">View post</a></p>

--- a/knowledge_repo/app/templates/email_templates/subscription_email.html
+++ b/knowledge_repo/app/templates/email_templates/subscription_email.html
@@ -1,19 +1,23 @@
-<table border="0" cellpadding="0" cellspacing="0" style="font-size: 13px">
-    <tbody>
-        <tr>
-            <td style="vertical-align: center; text-align: center; width: 150px">
-                <a href="{{ url_for('posts.render', path=page_id, _external=True) }}">
-                    <img height="200" src="cid:Thumb" />
-                </a>
-            </td>
-            <td style="padding-left: 10px">
-                <p style="font-size: 15px; font-weight: bold">{{ post_title }}</p>
-                <p style="margin: 5px 0">
-                    Author(s): <span style="font-style: italic">{{ post_authors|join(', ') }}</span>
-                    | Tag(s): <span style="font-style: italic">{{ post_tags|join(', ') }}</span>
-                </p>
-                <p>{{ post_tldr | safe }} <a href="{{ url_for('posts.render', path=page_id, _external=True) }}">View post</a></p>
-            </td>
-        </tr>
-    </tbody>
-</table>
+<html>
+    <body>
+        <table border="0" cellpadding="0" cellspacing="0" style="font-size: 13px">
+            <tbody>
+                <tr>
+                    <td style="vertical-align: center; text-align: center; width: 150px">
+                        <a href="{{ url_for('posts.render', path=page_id, _external=True) }}">
+                            <img height="200" src="cid:Thumb" />
+                        </a>
+                    </td>
+                    <td style="padding-left: 10px">
+                        <p style="font-size: 15px; font-weight: bold">{{ post_title }}</p>
+                        <p style="margin: 5px 0">
+                            Author(s): <span style="font-style: italic">{{ post_authors|join(', ') }}</span>
+                            | Tag(s): <span style="font-style: italic">{{ post_tags|join(', ') }}</span>
+                        </p>
+                        <p>{{ post_tldr | safe }} <a href="{{ url_for('posts.render', path=page_id, _external=True) }}">View post</a></p>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </body>
+</html>

--- a/knowledge_repo/app/templates/email_templates/subscription_email.txt
+++ b/knowledge_repo/app/templates/email_templates/subscription_email.txt
@@ -1,5 +1,9 @@
-A knowledge post was just posted under tag {{ full_tag }}
+Title: {{ post_title }}
+
+Author(s): {{ post_authors|join(', ') }}
+
+Tags(s): {{ post_tags|join(', ') }}
+
+{{ post_tldr | safe }}
 
 Link to post: {{ url_for('posts.render', path=page_id, _external=True) }}
-
-{{ post_text }}

--- a/knowledge_repo/app/utils/emails.py
+++ b/knowledge_repo/app/utils/emails.py
@@ -1,16 +1,16 @@
 """
 This file deals with all of the email functions.
 """
-
+import base64
 import logging
+import re
 
 from flask import render_template, current_app, url_for
 from flask_mail import Message
 
 from ..proxies import db_session
 from ..proxies import current_repo
-from ..models import Email, Subscription, User, Post
-from ..utils.render import render_post
+from ..models import Email, Subscription, User
 
 logger = logging.getLogger(__name__)
 
@@ -88,21 +88,42 @@ def send_subscription_email(post, tag):
         return
 
     default_recipients = ['knowledge_consumer@notreal.com']
-    subject = u"New knowledge post with tag [{}]!".format(tag.name)
-    msg = Message(subject=subject,
-                  recipients=default_recipients,
-                  bcc=recipients_bcc)
+    subject = u"New KR post: {}".format(post.title)
+    post_authors = [p.format_name for p in post.authors]
+    post_tags = [t.name for t in post.tags]
+    msg = Message(subject=subject, recipients=default_recipients, bcc=recipients_bcc)
 
-    # Iterate over fetched image files and attach them to email
-    post_text = render_post(post)
+    # Extract bytes from post thumbnail or fallback to the default one
+    if post.thumbnail:
+        reg_search = re.search('data:.*;base64,(.*)', post.thumbnail)
+        thumb_bytes = base64.b64decode(reg_search.group(1))
+    else:
+        with current_app.open_resource('static/images/default_thumbnail.png') as f:
+            thumb_bytes = f.read()
 
+    # Attach thumbnail to the email (base64 embedded images are not supported by many email clients)
+    msg.attach('thumb.png', 'image/png', thumb_bytes, 'inline', headers=[['Content-ID', '<Thumb>']])
+
+    # Plain mail
     msg.body = render_template("email_templates/subscription_email.txt",
                                full_tag=tag.name,
                                page_id=post.path,
-                               post_text=post_text,
+                               post_title=post.title,
+                               post_tldr=post.tldr,
+                               post_authors=post_authors,
+                               post_tags=post_tags,
                                knowledge_app_base_url=current_app.config['SERVER_NAME'])
 
-    msg.html = post_text
+    # Rich email
+    msg.html = render_template("email_templates/subscription_email.html",
+                               full_tag=tag.name,
+                               page_id=post.path,
+                               post_title=post.title,
+                               post_tldr=post.tldr,
+                               post_authors=post_authors,
+                               post_tags=post_tags,
+                               post_thumbnail=thumb_bytes,
+                               knowledge_app_base_url=current_app.config['SERVER_NAME'])
 
     for user in recipient_users:
         # mark email as sent just before you send the email
@@ -112,7 +133,7 @@ def send_subscription_email(post, tag):
                            object_id=post.id,
                            object_type="post",
                            subject=subject,
-                           text=post_text)
+                           text=msg.html)
         db_session.add(email_sent)
         db_session.commit()
 

--- a/knowledge_repo/app/utils/emails.py
+++ b/knowledge_repo/app/utils/emails.py
@@ -89,7 +89,7 @@ def send_subscription_email(post, tag):
         return
 
     default_recipients = ['knowledge_consumer@notreal.com']
-    subject = u"New knowledge post with tag [{}]!".format(tag.name)
+    subject = u"New knowledge post: {}".format(post.title)
     post_authors = [p.format_name for p in post.authors]
     post_tags = [t.name for t in post.tags]
     msg = Message(subject=subject, recipients=default_recipients, bcc=recipients_bcc)

--- a/tests/test_emails.py
+++ b/tests/test_emails.py
@@ -1,3 +1,4 @@
+import base64
 import unittest
 import datetime
 from sqlalchemy import and_
@@ -20,12 +21,15 @@ class EmailTest(unittest.TestCase):
 
         self.knowledge_username = 'email_test_user'
         self.post_path = 'tests/test_email_functionality'
+        self.thumbnail = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEX/TQBcNTh/AAAAAXR' \
+                         'STlPM0jRW/QAAAApJREFUeJxjYgAAAAYAAzY3fKgAAAAASUVORK5CYII='  # Red pixel
         kp = KnowledgePost(self.post_path)
 
         headers = {'title': 'Test Email Functionality',
                    'authors': [self.knowledge_username],
                    'tags': ['test_tag'],
                    'tldr': 'This is the test tldr for the post',
+                   'thumbnail': 'data:image/png;base64,{}'.format(self.thumbnail),
                    'created_at': datetime.date.today(),
                    'updated_at': datetime.date.today()}
         kp.write(md='Test Text', headers=headers)
@@ -140,7 +144,13 @@ class EmailTest(unittest.TestCase):
             assert len(emails_sent) == 1, 'One subscription email should recorded as sent'
             # Check outbox of messages
             assert len(outbox[0].bcc) == 1, 'One subscription email should be actually sent to one user'
-            assert "A knowledge post was just posted under tag" in outbox[0].body, 'Email should be the subscription email'
+            assert "Title: " in outbox[0].body, 'Plain email should use the txt template'
+            assert "cid:Thumb" in outbox[0].html, 'Rich email should use the html template'
+            # Check thumbnail attachment
+            assert len(outbox[0].attachments) == 1, 'One attachment should be sent'
+            thumbnail = outbox[0].attachments[0]
+            assert base64.b64decode(self.thumbnail) == thumbnail.data, 'Attachment should match'
+            assert [['Content-ID', '<Thumb>']] == thumbnail.headers, 'Attachment id should match'
 
             username_to_email = self.app.repository.config.username_to_email
             assert outbox[0].bcc[0] == username_to_email(self.knowledge_username)


### PR DESCRIPTION
## Changes
Change subscription emails to contain a summary of the post instead of the entire post. This should fix some recurring issues for reindexing.

Mostly using @jihonrado's changes from #517 + fixing up some issues with the thumbnail image.

## Test Plan
Tested on staging env. Received this email.

![image](https://user-images.githubusercontent.com/14146019/81218271-cb7a2b80-8f92-11ea-97b5-b9b0a3b8de7a.png)

## Reviewers
@etr2460 @john-bodley 