### PR TITLE
[index] Ensure force reindexing occurs regardless of if the index is up to date

### DIFF
--- a/knowledge_repo/app/index.py
+++ b/knowledge_repo/app/index.py
@@ -143,8 +143,8 @@ def update_index(check_timeouts=True, force=False, reindex=False):
     ):
         current_repo.update()
 
-    # Short-circuit if not the index master (unless force is True)
-    if not is_index_master and not force or index_up_to_date():
+    # Short-circuit if necessary
+    if not force and (not is_index_master or index_up_to_date()):
         return False
 
     try:


### PR DESCRIPTION
Description of changeset: 

This PR ensures that if we're forcing a reindex this should occur regardless of whether the index is deemed up to date. This ensures that the index is updated whenever a force reindex occurs.

Test Plan: 

Tested locally via the CLI reindex command.

to: @etr2460 
cc: @NiharikaRay 