### PR TITLE
Fix MathJax CDN URL

### DIFF
--- a/knowledge_repo/app/templates/markdown-presentation.html
+++ b/knowledge_repo/app/templates/markdown-presentation.html
@@ -35,7 +35,7 @@
   });
 </script>
 <script type="text/javascript"
-  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.8/MathJax.js">
+  src="https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js">
 </script>
 <script>
   $(".btn-presentation").addClass("btn-active");

--- a/knowledge_repo/app/templates/markdown-rendered.html
+++ b/knowledge_repo/app/templates/markdown-rendered.html
@@ -108,7 +108,7 @@
   });
 </script>
 <script type="text/javascript"
-  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.8/MathJax.js">
+  src="https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js">
 </script>
 
 <script>

--- a/knowledge_repo/app/templates/post_editor_base.html
+++ b/knowledge_repo/app/templates/post_editor_base.html
@@ -563,7 +563,7 @@ function parseDate(ds, error_name){
   });
 </script>
 <script type="text/javascript"
-  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.8/MathJax.js">
+  src="https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js">
 </script>
 
 {% endblock %}


### PR DESCRIPTION
## Description of changeset: 
MathJax is not available from the CDN URL due to https://github.com/mathjax/MathJax/issues/2450#issuecomment-639074282
## Test Plan: 

