### PR TITLE
Removing read of knowledge repo config file off default branch of master

### DIFF
--- a/knowledge_repo/repositories/gitrepository.py
+++ b/knowledge_repo/repositories/gitrepository.py
@@ -76,7 +76,7 @@ class GitKnowledgeRepository(KnowledgeRepository):
         if config.startswith('git:///'):
             assert config.endswith('.yml'), "In-repository configuration must be a YAML file."
             try:
-                self.config.update(yaml.safe_load(self.git_read(config.replace('git:///', ''))))
+                self.config.update(yaml.safe_load(config.replace('git:///', '')))
             except KeyError:
                 logger.warning("Repository missing configuration file: {}".format(config))
         else:


### PR DESCRIPTION
Fixes #569 

Description of changeset: 

It looks like you're reading the state of the config file of the knowledge repo off of the target branch which is hardcoded to default as master before there's any room to update the preference of what branch to use.

As a simple fix perhaps it's best to read the state of the config for the knowledge repo of whatever the active branch is instead? This alleviates the breakage when there is no master branch to check the file out from in the git of the knowledge repo.

Test Plan: 

Tried pytest, tried `bash run_tests.sh`, neither worked. I'm not sure if the issues are environmental and I should be using another tool to aid with them.


Would love to know how to help further! Figure this is at least a good starting point to help me learn more about your systems.