### PR TITLE
add default config for mysql database

### DIFF
--- a/knowledge_repo/app/config_defaults.py
+++ b/knowledge_repo/app/config_defaults.py
@@ -41,7 +41,7 @@ DEBUG = False
 # Database configuration
 # ---------------------------------------------------
 SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
-# But if you use mysql as database, you must specify the URI as demonstrated below.
+# If you are using a MySQL database, you must specify the URI as demonstrated below.
 # SQLALCHEMY_DATABASE_URI = 'mysql://username:password@hostname/database'
 SQLALCHEMY_ECHO = False
 SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/knowledge_repo/app/config_defaults.py
+++ b/knowledge_repo/app/config_defaults.py
@@ -41,6 +41,8 @@ DEBUG = False
 # Database configuration
 # ---------------------------------------------------
 SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
+# But if you use mysql as database, you must specify the URI as demonstrated below.
+# SQLALCHEMY_DATABASE_URI = 'mysql://username:password@hostname/database'
 SQLALCHEMY_ECHO = False
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 


### PR DESCRIPTION
Description of changeset: add DATABASE_URI for mysql defined as `SQLALCHEMY_DATABASE_URI = 'mysql://username:password@hostname/database'`.

Test Plan: I've tested on my local and production env with auto create tables from database defined on the URI which indicates as worked.
