### PR TITLE
Fix with_traceback calls

### DIFF
--- a/knowledge_repo/app/models.py
+++ b/knowledge_repo/app/models.py
@@ -136,7 +136,8 @@ class ErrorLog(db.Model):
                 db_session.rollback()
                 db_session.add(ErrorLog.from_exception(e))
                 db_session.commit()
-                raise e.with_traceback()
+                tb = sys.exc_info()[-1]
+                raise e.with_traceback(tb)
         return wrapped
 
 
@@ -189,7 +190,8 @@ class PageView(db.Model):
                 errorlog = ErrorLog.from_exception(e)
                 db_session.add(errorlog)
                 db_session.commit()
-                raise_with_traceback(e)
+                tb = sys.exc_info()[-1]
+                raise e.with_traceback(tb)
             finally:
                 # Extract object id and type after response generated (if requested) to ensure
                 # most recent data is collected

--- a/knowledge_repo/utils/encoding.py
+++ b/knowledge_repo/utils/encoding.py
@@ -22,7 +22,8 @@ def encode(data, encoding='utf-8'):
             data = data.encode(encoding)
         except Exception as e:
             if os.environ.get('DEBUG'):
-                raise e.with_traceback()
+                tb = sys.exc_info()[-1]
+                raise e.with_traceback(tb)
             logger.warning("An encoding error has occurred... continuing anyway. To capture these errors, rerun the current command prefixed with `DEBUG=1 `.")
             data = data.encode(encoding, errors='ignore')
     return data
@@ -35,7 +36,8 @@ def decode(data, encoding='utf-8'):
             data = data.decode(encoding)
         except Exception as e:
             if os.environ.get('DEBUG'):
-                raise e.with_traceback()
+                tb = sys.exc_info()[-1]
+                raise e.with_traceback(tb)
             logger.warning("An decoding error has occurred... continuing anyway. To capture these errors, rerun the current command prefixed with `DEBUG=1 `.")
             data = data.decode(encoding, errors='ignore')
     return data


### PR DESCRIPTION
What?
=====

* Fix calls to `with_traceback` to include a traceback parameter

Why?
=====

* We experienced errors within our errors:

```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File ".../python3.6/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File ".../python3.6/multiprocessing/process.py", line 93, in run
    self._target(*self._args, **self._kwargs)
  File ".../python3.6/site-packages/knowledge_repo/app/index.py", line 43, in index_sync_loop
    update_index(check_timeouts=False)
  File ".../python3.6/site-packages/knowledge_repo/app/models.py", line 139, in wrapped
    raise e.with_traceback()
TypeError: with_traceback() takes exactly one argument (0 given)
```

This doesn't do much, but clean up the error logs a bit so we can more quickly pin down the real problem.

Test Plan
========

- [x] Trigger an error and ensure the traceback no longer shows up.

For our current deployment, booting with more than one worker triggers this problem since we have the following error occur on startup:

```
Process Process-1:1:
Traceback (most recent call last):
  File ".../python3.6/site-packages/knowledge_repo/app/models.py", line 134, in wrapped
    return function(*args, **kwargs)
  File ".../python3.6/site-packages/knowledge_repo/app/index.py", line 141, in update_index
    current_repo.update()
  File ".../python3.6/site-packages/knowledge_repo/repositories/gitrepository.py", line 144, in update
    self.git.branches[branch].checkout()
  File ".../python3.6/site-packages/git/refs/head.py", line 219, in checkout
    self.repo.git.checkout(self, **kwargs)
  File ".../python3.6/site-packages/git/cmd.py", line 542, in <lambda>
    return lambda *args, **kwargs: self._call_process(name, *args, **kwargs)
  File ".../python3.6/site-packages/git/cmd.py", line 1005, in _call_process
    return self.execute(call, **exec_kwargs)
  File ".../python3.6/site-packages/git/cmd.py", line 822, in execute
    raise GitCommandError(command, status, stderr_value, stdout_value)
git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)
  cmdline: git checkout master
  stderr: 'fatal: Unable to create '.../repo/.git/index.lock': File exists.
```
