### PR TITLE
Add a multiprocessing lock to index syncing

### DIFF
--- a/knowledge_repo/app/index.py
+++ b/knowledge_repo/app/index.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 LOCKED = CHECKED = '1'
 UNLOCKED = '0'
 
+sync_lock = multiprocessing.Lock()
 
 def set_up_indexing_timers(app):
     if not app.config['INDEXING_ENABLED']:
@@ -39,9 +40,19 @@ def set_up_indexing_timers(app):
         def index_sync_loop(app):
             current_app.db.engine.dispose()
             while True:
-                with app.app_context():
-                    update_index(check_timeouts=False)
-                time.sleep(app.config['INDEXING_INTERVAL'])
+                sync_lock.acquire()
+                try:
+                    with app.app_context():
+                        print('*'*80)
+                        print(f'Thread {os.getpid()} (locked) calling update_index')
+                        print('*'*80)
+
+                        update_index(check_timeouts=False)
+                finally:
+                   print('*'*80)
+                   print(f'Process {os.getpid()} releasing lock')
+                   print('*'*80)
+                   sync_lock.release()
 
         app.index_watchdog = multiprocessing.Process(target=index_watchdog, args=(app,))
         app.index_watchdog.start()


### PR DESCRIPTION
Description of changeset: 

Add a lock to the code in charge of syncing the index

Test Plan: 

Run an instance using more than one gunicorn workers (this is a default, but a minimal example with 2 workers is shown below):

```
knowledge_repo --repo path/to/repo deploy -w 2
```

and ensure no more error messages show up that look like:

```
Process Process-1:1:
Traceback (most recent call last):
  File ".../python3.6/site-packages/knowledge_repo/app/models.py", line 134, in wrapped
    return function(*args, **kwargs)
  File ".../python3.6/site-packages/knowledge_repo/app/index.py", line 141, in update_index
    current_repo.update()
  File ".../python3.6/site-packages/knowledge_repo/repositories/gitrepository.py", line 144, in update
    self.git.branches[branch].checkout()
  File ".../python3.6/site-packages/git/refs/head.py", line 219, in checkout
    self.repo.git.checkout(self, **kwargs)
  File ".../python3.6/site-packages/git/cmd.py", line 542, in <lambda>
    return lambda *args, **kwargs: self._call_process(name, *args, **kwargs)
  File ".../python3.6/site-packages/git/cmd.py", line 1005, in _call_process
    return self.execute(call, **exec_kwargs)
  File ".../python3.6/site-packages/git/cmd.py", line 822, in execute
    raise GitCommandError(command, status, stderr_value, stdout_value)
git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)
  cmdline: git checkout master
  stderr: 'fatal: Unable to create '.../repo/.git/index.lock': File exists.
```