### PR TITLE
fix: decode the post.uuid before comparing it with other uuids

### DIFF
--- a/knowledge_repo/app/index.py
+++ b/knowledge_repo/app/index.py
@@ -153,9 +153,15 @@ def update_index(check_timeouts=True, force=False, reindex=False):
         posts = db_session.query(Post).all()
 
         for post in posts:
+            if isinstance(post.uuid, str) and post.uuid.starswith('\\x'):
+                decoded_post_uuid = bytes.fromhex(post.uuid.replace('\\x', ''))
+            elif isinstance(post.uuid, str):
+                decoded_post_uuid = bytes(post.uuid)
+            else:
+                decoded_post_uuid = post.uuid
 
             # If UUID has changed, check if we can find it elsewhere in the repository, and if so update index path
-            if post.uuid and ((post.path not in kr_dir) or (post.uuid != kr_dir[post.path].uuid)):
+            if post.uuid and ((post.path not in kr_dir) or (decoded_post_uuid != kr_dir[post.path].uuid)):
                 if post.uuid in kr_uuids:
                     logger.info('Updating location of post: {} -> {}'.format(post.path, kr_uuids[post.uuid].path))
                     post.path = kr_uuids[post.uuid].path
@@ -172,7 +178,7 @@ def update_index(check_timeouts=True, force=False, reindex=False):
             kp = kr_dir.pop(post.path)
 
             # Update metadata of post if required
-            if reindex or (kp.revision > post.revision or not post.is_published or kp.uuid != post.uuid):
+            if reindex or (kp.revision > post.revision or not post.is_published or kp.uuid != decoded_post_uuid):
                 if kp.is_valid():
                     logger.info('Recording update to post at: {}'.format(kp.path))
                     post.update_metadata_from_kp(kp)


### PR DESCRIPTION
What?
======

We encountered a problem where the `uuid` of our posts looks like a hex string, but it is being compared with `bytes` on the `kr_dir` and `kp` objects. This bit of logic ensures we are comparing apples to apples by forcing the `post.uuid` to be decoded if it is a hex string and coercing it to a `bytes` object as comparing a `str` to a `bytes` will never result in equality.

Why?
=====

The reason for this change, is that any update to our knowledge repo becomes a reindex of _all_ posts which means our consumers have to wait to see their new posts. This should drastically reduce the amount of work per reindex operation.


Description of changeset: 

* Change how `post.uuid` is compared to existing data.

Test Plan: 

- [ ] Make an edit in a repository and ensure the resulting `update_index` that gets triggered does not rewrite everything.