### PR TITLE
fix with_traceback calls

### DIFF
--- a/knowledge_repo/app/models.py
+++ b/knowledge_repo/app/models.py
@@ -137,7 +137,7 @@ class ErrorLog(db.Model):
                 db_session.add(ErrorLog.from_exception(e))
                 db_session.commit()
                 tb = sys.exc_info()[2]
-                raise e.with_traceback(tb)
+                raise e.with_traceback(tb=sys.exc_info()[2])
         return wrapped
 
 
@@ -191,7 +191,7 @@ class PageView(db.Model):
                 db_session.add(errorlog)
                 db_session.commit()
                 tb = sys.exc_info()[2]
-                raise e.with_traceback(tb)
+                raise e.with_traceback(tb=sys.exc_info()[2])
             finally:
                 # Extract object id and type after response generated (if requested) to ensure
                 # most recent data is collected

--- a/knowledge_repo/app/models.py
+++ b/knowledge_repo/app/models.py
@@ -136,7 +136,8 @@ class ErrorLog(db.Model):
                 db_session.rollback()
                 db_session.add(ErrorLog.from_exception(e))
                 db_session.commit()
-                raise e.with_traceback()
+                tb = sys.exc_info()[2]
+                raise e.with_traceback(tb)
         return wrapped
 
 
@@ -189,7 +190,8 @@ class PageView(db.Model):
                 errorlog = ErrorLog.from_exception(e)
                 db_session.add(errorlog)
                 db_session.commit()
-                raise e.with_traceback()
+                tb = sys.exc_info()[2]
+                raise e.with_traceback(tb)
             finally:
                 # Extract object id and type after response generated (if requested) to ensure
                 # most recent data is collected

--- a/knowledge_repo/utils/encoding.py
+++ b/knowledge_repo/utils/encoding.py
@@ -23,7 +23,7 @@ def encode(data, encoding='utf-8'):
         except Exception as e:
             if os.environ.get('DEBUG'):
                 tb = sys.exc_info()[2]
-                raise e.with_traceback(tb)
+                raise e.with_traceback(tb=sys.exc_info()[2])
             logger.warning("An encoding error has occurred... continuing anyway. To capture these errors, rerun the current command prefixed with `DEBUG=1 `.")
             data = data.encode(encoding, errors='ignore')
     return data
@@ -37,7 +37,7 @@ def decode(data, encoding='utf-8'):
         except Exception as e:
             if os.environ.get('DEBUG'):
                 tb = sys.exc_info()[2]
-                raise e.with_traceback(tb)
+                raise e.with_traceback(tb=sys.exc_info()[2])
             logger.warning("An decoding error has occurred... continuing anyway. To capture these errors, rerun the current command prefixed with `DEBUG=1 `.")
             data = data.decode(encoding, errors='ignore')
     return data

--- a/knowledge_repo/utils/encoding.py
+++ b/knowledge_repo/utils/encoding.py
@@ -22,7 +22,8 @@ def encode(data, encoding='utf-8'):
             data = data.encode(encoding)
         except Exception as e:
             if os.environ.get('DEBUG'):
-                raise e.with_traceback()
+                tb = sys.exc_info()[2]
+                raise e.with_traceback(tb)
             logger.warning("An encoding error has occurred... continuing anyway. To capture these errors, rerun the current command prefixed with `DEBUG=1 `.")
             data = data.encode(encoding, errors='ignore')
     return data
@@ -35,7 +36,8 @@ def decode(data, encoding='utf-8'):
             data = data.decode(encoding)
         except Exception as e:
             if os.environ.get('DEBUG'):
-                raise e.with_traceback()
+                tb = sys.exc_info()[2]
+                raise e.with_traceback(tb)
             logger.warning("An decoding error has occurred... continuing anyway. To capture these errors, rerun the current command prefixed with `DEBUG=1 `.")
             data = data.decode(encoding, errors='ignore')
     return data


### PR DESCRIPTION
Description of changeset:  

`with_traceback` requires a traceback argument, but we're missing it.
```
builtins:TypeError: with_traceback() takes exactly one argument (0 given)
```

Updated usages of `with_traceback` to pass in the traceback. Based off example [in python docs](https://docs.python.org/3/library/exceptions.html#BaseException.with_traceback).

This is basically a duplicate of #584, but up-to-date with master.

Test Plan: 
Tested in python shell.

@john-bodley @etr2460
