### PR TITLE
[fix] yaml safe_load -> full_load

### DIFF
--- a/knowledge_repo/post.py
+++ b/knowledge_repo/post.py
@@ -332,7 +332,7 @@ class KnowledgePost(object):
         try:
             if not yaml_str.strip().startswith('---'):
                 raise StopIteration()
-            return next(yaml.safe_load_all(yaml_str))
+            return next(yaml.full_load_all(yaml_str))
         except yaml.YAMLError as e:
             logger.info(
                 "YAML header is incorrectly formatted or missing. The following "


### PR DESCRIPTION
# Description of changeset: 
#547 had switched from `yaml.load_all` to `yaml.safe_load_all` because vanilla `load_all` is no longer recommended. This new behavior caused a few of our existing posts. The behavior of `yaml.full_load_all` seems more similar to the previous behavior, so this PR switches to using that function.

# Test Plan: 
Deployed changes, confirmed that this fixed the broken posts

cc:
@bulam @naoyak 