### PR TITLE
Don't use a dot delimiter for naming auth_provider blueprints

### DIFF
--- a/knowledge_repo/app/auth_provider.py
+++ b/knowledge_repo/app/auth_provider.py
@@ -23,7 +23,7 @@ class KnowledgeAuthProvider(object, metaclass=SubclassRegisteringABCMeta):
     def __init__(self, name, app=None, **kwargs):
         self.name = name
         self.app = app
-        self.blueprint = Blueprint('auth_provider.' + self.name, __name__, template_folder='../templates')
+        self.blueprint = Blueprint('auth_provider_' + self.name, __name__, template_folder='../templates')
         self.prepare_blueprint(self.blueprint)
         self.init(**kwargs)
 

--- a/knowledge_repo/app/routes/auth.py
+++ b/knowledge_repo/app/routes/auth.py
@@ -16,7 +16,7 @@ def login():
     providers = current_app.auth_providers
 
     if len(providers) == 1:
-        return redirect(url_for('auth_provider.{}.prompt'.format(providers[0].name)))
+        return redirect(url_for('auth_provider_{}.prompt'.format(providers[0].name)))
 
     return render_template(
         'auth-switcher.html',


### PR DESCRIPTION
This pull request fixes #594. 

Description of changeset: Changed the naming scheme for `auth_provider` blueprints.

Test Plan: It seems like the test suite is broken, but in testing this appears to fix the issue.

