### PR TITLE
add package build and publish workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,12 +14,17 @@ jobs:
         os: ["ubuntu-18.04", "macos-latest"]
         python-version: ['3.6', '3.7', '3.8', '3.9']
     steps:
-      - uses: actions/checkout@v2
-      - uses: conda-incubator/setup-miniconda@v2
+      - name: Checkout source
+        uses: actions/checkout@v2
+
+      - name: Set up Python Test Env and Python
+        uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: test
           python-version: '${{ matrix.python-version }}'
-      - shell: bash -l {0}
+
+      - name: CI Tests
+        shell: bash -l {0}
         run: |
           conda update --all --yes
           conda config --set always_yes yes --set changeps1 no

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,0 +1,46 @@
+name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+
+on: push
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+    runs-on: ubuntu-18.04
+
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@master
+    
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        --user
+    
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+        .
+
+    - name: Publish distribution 📦 to Test PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+
+    # uncomment after verify with Test PyPI
+    # - name: Publish distribution 📦 to PyPI
+    #   if: startsWith(github.ref, 'refs/tags')
+    #   uses: pypa/gh-action-pypi-publish@master
+    #   with:
+    #     password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Description of changeset: 

1. add task name to main workflow
2. add Build and publish workflow to pypi

by following: https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/

Test Plan: 
[x] verfiy on with test Test PyPI

@csharplus @etr2460 