### PR TITLE
fix: Login authentication links were broken

### DIFF
--- a/knowledge_repo/app/templates/auth-switcher.html
+++ b/knowledge_repo/app/templates/auth-switcher.html
@@ -30,7 +30,7 @@ Knowledge Repo Login
 </span>
 <ul class='auth-providers'>
   {% for provider in providers %}
-  <li><a href='login/{{ provider[' name'] }}?next={{request.args.next}}'><img src='{{ provider[' icon_uri'] }}' />{{
+  <li><a href='login/{{ provider['name'] }}?next={{request.args.next}}'><img src='{{ provider['icon_uri'] }}' />{{
       provider['link_text'] }}</a></li>
   {% endfor %}
 </ul>


### PR DESCRIPTION
Description of changeset: 

The links inside /auth/login are broken at least when using Python 3.10

Test Plan: 

Enter into the page  /auth/login with Google Auth enabled.
The links are now working and the icons are not broken