### PR TITLE
Avoid printing-out exception errors when REVISION or UUID files are not found

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,8 @@
         "editor.formatOnSave": false
     },
     "eslint.autoFixOnSave": true,
-    "tslint.autoFixOnSave": true
+    "tslint.autoFixOnSave": true,
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": true
+    }
 }

--- a/knowledge_repo/repositories/folder.py
+++ b/knowledge_repo/repositories/folder.py
@@ -12,19 +12,19 @@ logger = logging.getLogger(__name__)
 
 
 class FolderKnowledgeRepository(KnowledgeRepository):
-    _registry_keys = ['', 'file']
+    _registry_keys = ["", "file"]
 
     TEMPLATES = {
-        'README.md': get_path(
-            __file__, '../templates', 'repository_readme.md'),
-        '.knowledge_repo_config.yml': get_path(
-            __file__, '../templates', 'repository_config.yml'),
+        "README.md": get_path(__file__, "../templates", "repository_readme.md"),
+        ".knowledge_repo_config.yml": get_path(
+            __file__, "../templates", "repository_config.yml"
+        ),
     }
 
     @classmethod
     def create(cls, uri, embed_tooling=False):
-        if uri.startswith('file://'):
-            uri = uri[len('file://'):]
+        if uri.startswith("file://"):
+            uri = uri[len("file://") :]
         path = os.path.abspath(uri)
         if not os.path.exists(path):
             os.makedirs(path)
@@ -46,15 +46,16 @@ class FolderKnowledgeRepository(KnowledgeRepository):
         explicitly requested via the 'file://' protocol.
         """
         check_for_git = True
-        if uri.startswith('file://'):
+        if uri.startswith("file://"):
             check_for_git = False
-            uri = uri[len('file://'):]
-        if check_for_git and os.path.exists(os.path.join(uri, '.git')):
+            uri = uri[len("file://") :]
+        if check_for_git and os.path.exists(os.path.join(uri, ".git")):
             from .gitrepository import GitKnowledgeRepository
+
             return GitKnowledgeRepository(uri, *args, **kwargs)
         return cls(uri, *args, **kwargs)
 
-    def init(self, config='.knowledge_repo_config.yml', auto_create=False):
+    def init(self, config=".knowledge_repo_config.yml", auto_create=False):
         self.auto_create = auto_create
         self.path = self.uri
         self.config.update(os.path.join(self.path, config))
@@ -65,7 +66,7 @@ class FolderKnowledgeRepository(KnowledgeRepository):
 
     @path.setter
     def path(self, path):
-        assert isinstance(path, str), 'The path specified must be a string.'
+        assert isinstance(path, str), "The path specified must be a string."
         path = os.path.abspath(os.path.expanduser(path))
         if not os.path.exists(path):
             path = os.path.abspath(path)
@@ -82,11 +83,11 @@ class FolderKnowledgeRepository(KnowledgeRepository):
 
     @property
     def status(self):
-        return 'OK'
+        return "OK"
 
     @property
     def status_message(self):
-        return 'OK'
+        return "OK"
 
     # ---------------- Post retrieval methods --------------------------------
 
@@ -95,26 +96,27 @@ class FolderKnowledgeRepository(KnowledgeRepository):
 
         if self.PostStatus.PUBLISHED in statuses:
 
-            for path, folders, files in os.walk(
-                    os.path.join(self.path, prefix or '')):
+            for path, folders, files in os.walk(os.path.join(self.path, prefix or "")):
 
                 # Do not visit hidden folders
                 for folder in folders:
-                    if folder.startswith('.'):
+                    if folder.startswith("."):
                         folders.remove(folder)
 
                 posts.update(
-                    os.path.join(os.path.relpath(
-                        path, start=self.path), folder)
-                    for folder in folders if folder.endswith('.kp')
+                    os.path.join(os.path.relpath(path, start=self.path), folder)
+                    for folder in folders
+                    if folder.endswith(".kp")
                 )
                 posts.update(
                     os.path.join(os.path.relpath(path, start=self.path), file)
-                    for file in files if file.endswith('.kp')
+                    for file in files
+                    if file.endswith(".kp")
                 )
 
-        for post in sorted([post[2:] if post.startswith('./')
-                            else post for post in posts]):
+        for post in sorted(
+            [post[2:] if post.startswith("./") else post for post in posts]
+        ):
             yield post
 
     # ------------- Post submission / addition user flow ----------------------
@@ -143,14 +145,15 @@ class FolderKnowledgeRepository(KnowledgeRepository):
 
     def _kp_uuid(self, path):
         try:
-            return self._kp_read_ref(path, 'UUID')
+            return self._kp_read_ref(path, "UUID")
         except Exception as ex:
-            logger.info(f'Existing UUID file was not found.')
+            logger.info(f"Existing UUID file was not found.")
             return None
 
     def _kp_path(self, path, rel=None):
         return KnowledgeRepository._kp_path(
-            self, os.path.expanduser(path), rel=rel or self.path)
+            self, os.path.expanduser(path), rel=rel or self.path
+        )
 
     def _kp_exists(self, path, revision=None):
         return os.path.exists(os.path.join(self.path, path))
@@ -162,9 +165,9 @@ class FolderKnowledgeRepository(KnowledgeRepository):
         # We use a 'REVISION' file in the knowledge post folder rather than
         # using git revisions because using git rev-parse is slow.
         try:
-            return int(self._kp_read_ref(path, 'REVISION'))
+            return int(self._kp_read_ref(path, "REVISION"))
         except Exception as ex:
-            logger.info(f'Existing REVISION file was not found.')
+            logger.info(f"Existing REVISION file was not found.")
             return 0
 
     def _kp_get_revisions(self, path):
@@ -173,9 +176,9 @@ class FolderKnowledgeRepository(KnowledgeRepository):
     def _kp_write_ref(self, path, reference, data, uuid=None, revision=None):
         path = os.path.join(self.path, path)
         if os.path.isfile(path):
-            kp = KnowledgePost.from_file(path, format='kp')
+            kp = KnowledgePost.from_file(path, format="kp")
             kp._write_ref(reference, data)
-            kp.to_file(path, format='kp')
+            kp.to_file(path, format="kp")
         else:
             ref_path = os.path.join(path, reference)
             ref_dir = os.path.dirname(ref_path)
@@ -189,15 +192,15 @@ class FolderKnowledgeRepository(KnowledgeRepository):
         if os.path.isdir(path):
             if parent:
                 path = os.path.join(path, parent)
-            for dirpath, dirnames, filenames in os.walk(
-                    os.path.join(self.path, path)):
+            for dirpath, dirnames, filenames in os.walk(os.path.join(self.path, path)):
                 for filename in filenames:
-                    if dirpath == '' and filename == 'REVISION':
+                    if dirpath == "" and filename == "REVISION":
                         continue
-                    yield os.path.relpath(os.path.join(
-                        dirpath, filename), os.path.join(self.path, path))
+                    yield os.path.relpath(
+                        os.path.join(dirpath, filename), os.path.join(self.path, path)
+                    )
         else:
-            kp = KnowledgePost.from_file(path, format='kp')
+            kp = KnowledgePost.from_file(path, format="kp")
             for reference in kp._dir(parent=parent):
                 yield reference
 
@@ -207,22 +210,21 @@ class FolderKnowledgeRepository(KnowledgeRepository):
         if os.path.isdir(path):
             return os.path.isfile(os.path.join(path, reference))
         else:
-            kp = KnowledgePost.from_file(path, format='kp')
+            kp = KnowledgePost.from_file(path, format="kp")
             return kp._has_ref(reference)
 
     def _kp_diff(self, path, head, base):
         raise NotImplementedError
 
     def _kp_new_revision(self, path, uuid=None):
-        self._kp_write_ref(path, 'REVISION', encode(
-            self._kp_get_revision(path) + 1))
+        self._kp_write_ref(path, "REVISION", encode(self._kp_get_revision(path) + 1))
         if uuid:
-            self._kp_write_ref(path, 'UUID', encode(uuid))
+            self._kp_write_ref(path, "UUID", encode(uuid))
 
     def _kp_read_ref(self, path, reference, revision=None):
         path = os.path.join(self.path, path)
         if os.path.isdir(path):
             return read_binary(os.path.join(self.path, path, reference))
         else:
-            kp = KnowledgePost.from_file(path, format='kp')
+            kp = KnowledgePost.from_file(path, format="kp")
             return kp._read_ref(reference)

--- a/knowledge_repo/repositories/folder.py
+++ b/knowledge_repo/repositories/folder.py
@@ -144,8 +144,8 @@ class FolderKnowledgeRepository(KnowledgeRepository):
     def _kp_uuid(self, path):
         try:
             return self._kp_read_ref(path, 'UUID')
-        except Exception as e:
-            print(f'Exception encountered: {e}')
+        except Exception as ex:
+            logger.info(f'Existing UUID file was not found.')
             return None
 
     def _kp_path(self, path, rel=None):
@@ -163,8 +163,8 @@ class FolderKnowledgeRepository(KnowledgeRepository):
         # using git revisions because using git rev-parse is slow.
         try:
             return int(self._kp_read_ref(path, 'REVISION'))
-        except Exception as e:
-            print(f'Exception encountered: {e}')
+        except Exception as ex:
+            logger.info(f'Existing REVISION file was not found.')
             return 0
 
     def _kp_get_revisions(self, path):

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -13,7 +13,7 @@ rm -f .coverage &> /dev/null
 set -e
 
 # Run pep8 tests
-pycodestyle knowledge_repo scripts tests setup.py --exclude knowledge_repo/app/migrations,tests/test_repo --ignore=E501,E722,W503,W504
+pycodestyle knowledge_repo scripts tests setup.py --exclude knowledge_repo/app/migrations,tests/test_repo --ignore=E203,E501,E722,W503,W504
 
 # Create fake repository and add some sample posts.
 # We use a fake repository here to speed things up, and to avoid using git in test environments


### PR DESCRIPTION
Description of changeset:

When creating a new post with the `knowledge_repo` tool, missing REVISION or UUID files are expected, and should not lead to exception messages.

Test Plan:
CI

Reviewers:
@JJJ000 @mengting1010 