### PR TITLE
Remove the # symbol before tags to avoid unnecessary confusion

### DIFF
--- a/knowledge_repo/app/templates/index-feed.html
+++ b/knowledge_repo/app/templates/index-feed.html
@@ -30,7 +30,7 @@
             </button></div>"
     {% endif %}
         class="text" style="font-size:0.9em;">
-      {{ "#" + tag }}
+      {{ tag }}
     </a>
 {% endmacro %}
 

--- a/knowledge_repo/app/templates/index-table.html
+++ b/knowledge_repo/app/templates/index-table.html
@@ -62,9 +62,9 @@
           {% for tag_obj in post.tags %}
             {% set tag = tag_obj.name %}
             {% if loop.last %}
-               <a href="/tag_pages?tag={{ tag|urlencode }}">{{ "#" + tag}}</a>
+               <a href="/tag_pages?tag={{ tag|urlencode }}">{{ tag }}</a>
               {% else %}
-               <a href="/tag_pages?tag={{ tag|urlencode }}">{{ "#" + tag}}</a>,
+               <a href="/tag_pages?tag={{ tag|urlencode }}">{{ tag }}</a>,
               {% endif %}
           {% endfor %}
       </td>

--- a/knowledge_repo/app/templates/markdown-rendered.html
+++ b/knowledge_repo/app/templates/markdown-rendered.html
@@ -226,7 +226,7 @@ $.each(tags_list, function(i,tag){
   ahref = document.createElement("a")
   e_tag = encodeURIComponent(tag)
   f_tag = tag.replace("/", "__")
-  tag_name = "#" + tag
+  tag_name = tag
   tag_subscription_button_id_name = "tag-subscription-" + i + "__" + f_tag
   ahref.setAttribute("data-container", "body")
   ahref.setAttribute("data-toggle", "popover")

--- a/knowledge_repo/app/templates/tag_pages.html
+++ b/knowledge_repo/app/templates/tag_pages.html
@@ -80,7 +80,7 @@
                        </button></div>"
                     {% endif %}
                     class="text">
-                  {{ "#" + tag}}
+                  {{ tag }}
                 </a>
               {% endfor %}
             </li>


### PR DESCRIPTION
Description of changeset:
Currently all tags are displayed with "#" prefix, which is unnecessary, and also could be confused with some real tag symbols, e.g., "C#".

Test Plan:
CI

Reviewers:
@JJJ000 @mengting1010 