### PR TITLE
Fix the cluster id issue with special characters `#` and `.` in tags

### DIFF
--- a/knowledge_repo/app/templates/base.html
+++ b/knowledge_repo/app/templates/base.html
@@ -62,13 +62,8 @@
   {% block extra_headers %}
   {% endblock %}
   <style>
-    {
-      % block style %
-    }
-
-      {
-      % endblock %
-    }
+    {% block style %}
+    {% endblock %}
   </style>
 </head>
 

--- a/knowledge_repo/app/templates/index-base.html
+++ b/knowledge_repo/app/templates/index-base.html
@@ -36,7 +36,6 @@
           <i class="glyphicon glyphicon-chevron-right"></i>
         </a>
       </div>
-
     {% endif %}
   {% endif %}
 {% endmacro %}
@@ -56,9 +55,8 @@
       </li>
       <span class="text" style="display:inline-flex;text-align:justify;align-items:center;line-height:35px;"> &nbsp;per page</span>
     </ul>
-{% endif %}
+  {% endif %}
 {% endmacro %}
-
 
 {% block content %}
   <!-- Index rendering mode switch -->

--- a/knowledge_repo/app/templates/index-cluster.html
+++ b/knowledge_repo/app/templates/index-cluster.html
@@ -56,7 +56,7 @@
       </li>
     {%- else %}
       {%- if contents|length > 0 and cluster|length > 0 %}
-      {% set cluster_id = cluster|replace(' ', '__')|replace('-', '__') %}
+      {% set cluster_id = cluster|replace(' ', '__')|replace('-', '__')|replace('#', '__')|replace('.', '__') %}
         <li id="{{ cluster_id|safe }}" class="cluster_dir" style="list-style-type:disc">
           <div>
             <h6 style="margin-bottom:0;margin-top:0">


### PR DESCRIPTION
Description of changeset:

When tags contain `#` or `.`, the cluster id generated does not behave correctly in HTML.

Test Plan:
CI

Reviewers:
@JJJ000 @mengting1010 