### PR TITLE
Refactor the code in FlaskDeployer

### DIFF
--- a/knowledge_repo/app/deploy/flask.py
+++ b/knowledge_repo/app/deploy/flask.py
@@ -3,7 +3,7 @@ from .common import KnowledgeDeployer
 
 class FlaskDeployer(KnowledgeDeployer):
 
-    registry_keys = ['flask']
+    _registry_keys = ['flask']
 
     def start(self, **kwargs):
         self.app.start_indexing()

--- a/knowledge_repo/app/deploy/flask.py
+++ b/knowledge_repo/app/deploy/flask.py
@@ -3,10 +3,13 @@ from .common import KnowledgeDeployer
 
 class FlaskDeployer(KnowledgeDeployer):
 
-    _registry_keys = ['flask']
+    registry_keys = ['flask']
+
+    def start(self, **kwargs):
+        self.app.start_indexing()
 
     def run(self, **kwargs):
-        self.app.start_indexing()
+        self.start()
         return self.app.run(
             debug=self.app.config['DEBUG'],
             host=self.host,


### PR DESCRIPTION
Description of changeset:

In this refactored version, the `run` method has been split into two separate methods: `start` and `run`. The `start` method starts indexing, and the `run` method runs the application. This separation makes the code more readable and maintainable.

Test Plan:
CI

Reviewers:
@JJJ000 @mengting1010