### PR TITLE
Increase the timeout value for indexing

### DIFF
--- a/knowledge_repo/app/config_defaults.py
+++ b/knowledge_repo/app/config_defaults.py
@@ -273,7 +273,7 @@ def prepare_repo(repo):
 # requesting process. Note that `INDEXING_TIMEOUT` must be larger than
 # `INDEXING_INTERVAL` or strange things might begin to happen.
 INDEXING_INTERVAL = 5 * 60  # 5 minutes
-INDEXING_TIMEOUT = 10 * 60  # 10 minutes
+INDEXING_TIMEOUT = 60 * 60  # 60 minutes
 
 # Whether an index operation should update repositories
 INDEXING_UPDATES_REPOSITORIES = True


### PR DESCRIPTION
Description of changeset:

Indexing process could take more than 10 minutes, which was the old setting value. It caused early abortion of the indexing process.

Test Plan:
CI

Reviewers:
@JJJ000 @mengting1010 