### PR TITLE
Add a new launch setting for local development and upgrade the Ubuntu version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,11 +11,11 @@ on:
 
 jobs:
   Build:
-    runs-on: '${{ matrix.os }}'
+    runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        os: ['ubuntu-18.04', 'macos-latest']
-        python-version: ['3.7', '3.8', '3.9']
+        os: ["ubuntu-22.04", "macos-latest"]
+        python-version: ["3.7", "3.8", "3.9"]
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
@@ -24,7 +24,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: test
-          python-version: '${{ matrix.python-version }}'
+          python-version: "${{ matrix.python-version }}"
 
       - name: CI Tests
         shell: bash -l {0}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,41 +1,41 @@
 name: Publish Python 🐍 distributions 📦 to PyPI
 
 on:
-  release: 
+  release:
     types: [created]
   workflow_dispatch:
 
 jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
-    - name: Checkout source
-      uses: actions/checkout@master
-    
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.8
-    
-    - name: Install pypa/build
-      run: >-
-        python -m
-        pip install
-        build
-        --user
-    
-    - name: Build a binary wheel and a source tarball
-      run: >-
-        python -m
-        build
-        --sdist
-        --wheel
-        --outdir dist/
-        .
+      - name: Checkout source
+        uses: actions/checkout@master
 
-    - name: Publish distribution 📦 to PyPI
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+
+      - name: Install pypa/build
+        run: >-
+          python -m
+          pip install
+          build
+          --user
+
+      - name: Build a binary wheel and a source tarball
+        run: >-
+          python -m
+          build
+          --sdist
+          --wheel
+          --outdir dist/
+          .
+
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -6,35 +6,35 @@ on:
 jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
-    - name: Checkout source
-      uses: actions/checkout@master
-    
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.8
-    
-    - name: Install pypa/build
-      run: >-
-        python -m
-        pip install
-        build
-        --user
-    
-    - name: Build a binary wheel and a source tarball
-      run: >-
-        python -m
-        build
-        --sdist
-        --wheel
-        --outdir dist/
-        .
+      - name: Checkout source
+        uses: actions/checkout@master
 
-    - name: Publish distribution 📦 to Test PyPI
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+
+      - name: Install pypa/build
+        run: >-
+          python -m
+          pip install
+          build
+          --user
+
+      - name: Build a binary wheel and a source tarball
+        run: >-
+          python -m
+          build
+          --sdist
+          --wheel
+          --outdir dist/
+          .
+
+      - name: Publish distribution 📦 to Test PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,20 @@
             ]
         },
         {
+            "name": "Run Server Locally with a Git repo",
+            "type": "python",
+            "request": "launch",
+            "program": "scripts/knowledge_repo",
+            "console": "integratedTerminal",
+            "args": [
+                "--repo",
+                "~/test_repo",
+                "runserver",
+                "--port",
+                "7001"
+            ]
+        },
+        {
             "name": "Run Server Locally with config",
             "type": "python",
             "request": "launch",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 LABEL description="knowledge-repo service"
 


### PR DESCRIPTION
Description of changeset:

To use a local Git repo for development, a new launch configuration is added with appropriate settings. As Ubuntu `18.04` has been deprecated, it has been upgraded to `22.04`.

Test Plan:
CI

Reviewers:
@JJJ000 @mengting1010 